### PR TITLE
Add new model from OpenRouter

### DIFF
--- a/ai/providers.ts
+++ b/ai/providers.ts
@@ -228,6 +228,7 @@ const languageModels = {
   "openrouter/sentientagi/dobby-mini-unhinged-plus-llama-3.1-8b": openrouterClient("sentientagi/dobby-mini-unhinged-plus-llama-3.1-8b"),
   "openrouter/minimax/minimax-m1": openrouterClient("minimax/minimax-m1"),
   "openrouter/minimax/minimax-m1:extended": openrouterClient("minimax/minimax-m1:extended"),
+  "openrouter/inception/mercury": openrouterClient("inception/mercury"),
   // Requesty models
   "requesty/openai/gpt-4o": requestyClient("openai/gpt-4o"),
   "requesty/openai/gpt-4o-mini": requestyClient("openai/gpt-4o-mini"),
@@ -384,6 +385,8 @@ export const getLanguageModelWithKeys = (modelId: string, apiKeys?: Record<strin
       return getOpenRouterClient()("minimax/minimax-m1");
     case "openrouter/minimax/minimax-m1:extended":
       return getOpenRouterClient()("minimax/minimax-m1:extended");
+    case "openrouter/inception/mercury":
+      return getOpenRouterClient()("inception/mercury");
 
     // Requesty models
     case "requesty/openai/gpt-4o":
@@ -856,6 +859,16 @@ export const modelDetails: Record<keyof typeof languageModels, ModelInfo> = {
     enabled: true,
     supportsWebSearch: true,
     premium: true
+  },
+  "openrouter/inception/mercury": {
+    provider: "OpenRouter",
+    name: "Inception Mercury",
+    description: "Mercury is the first diffusion large language model (dLLM). Applying a breakthrough discrete diffusion approach, the model runs 5-10x faster than even speed optimized models like GPT-4.1 Nano and Claude 3.5 Haiku while matching their performance. Mercury's speed enables developers to provide responsive user experiences, including with voice agents, search interfaces, and chatbots.",
+    apiVersion: "inception/mercury",
+    capabilities: ["Ultra-fast", "Speed Optimized", "Voice Agents", "Search Interfaces", "Chatbots", "Responsive UI"],
+    enabled: true,
+    supportsWebSearch: true,
+    premium: false
   },
   // Requesty model details
   "requesty/openai/gpt-4o": {

--- a/scripts/openrouter-pricing-analysis.ts
+++ b/scripts/openrouter-pricing-analysis.ts
@@ -80,7 +80,8 @@ const openRouterModels = [
     'qwen/qwq-32b',
     'qwen/qwen3-235b-a22b',
     'anthropic/claude-sonnet-4',
-    'anthropic/claude-opus-4'
+    'anthropic/claude-opus-4',
+    'inception/mercury'
 ];
 
 // Model display names mapping
@@ -108,7 +109,8 @@ const modelDisplayNames: Record<string, string> = {
     'qwen/qwq-32b': 'Qwen QWQ 32B',
     'qwen/qwen3-235b-a22b': 'Qwen3 235B A22B',
     'anthropic/claude-sonnet-4': 'Claude 4 Sonnet',
-    'anthropic/claude-opus-4': 'Claude 4 Opus'
+    'anthropic/claude-opus-4': 'Claude 4 Opus',
+    'inception/mercury': 'Inception Mercury'
 };
 
 async function fetchOpenRouterModels(): Promise<OpenRouterModel[]> {


### PR DESCRIPTION
Add Inception Mercury model from OpenRouter to enable its use in the application and for pricing analysis.