### PR TITLE
refactor(chat): decompose POST /api/chat and fix message ordering

### DIFF
--- a/.agents/skills/thermo-nuclear-code-quality-review/SKILL.md
+++ b/.agents/skills/thermo-nuclear-code-quality-review/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: thermo-nuclear-code-quality-review
+description: Run an extremely strict maintainability review for abstraction quality, giant files, and spaghetti-condition growth. Use for a thermo-nuclear code quality review, thermonuclear review, deep code quality audit, or especially harsh maintainability review.
+disable-model-invocation: true
+---
+
+# Thermo-Nuclear Code Quality Review
+
+Use this skill for an unusually strict review focused on implementation quality, maintainability, abstraction quality, and codebase health.
+
+Above all, this skill should push the reviewer to be **ambitious** about code structure. Do not merely identify local cleanup opportunities. Actively search for "code judo" moves: restructurings that preserve behavior while making the implementation dramatically simpler, smaller, more direct, and more elegant.
+
+## Core Prompt
+
+Start from this baseline:
+
+> Perform a deep code quality audit of the current branch's changes.
+> Rethink how to structure / implement the changes to meaningfully improve code quality without impacting behavior.
+> Work to improve abstractions, modularity, reduce Spaghetti code, improve succinctness and legibility.
+> Be ambitious, if there is a clear path to improving the implementation that involves restructuring some of the codebase, go for it.
+> Be extremely thorough and rigorous. Measure twice, cut once.
+
+## Non-Negotiable Additional Standards
+
+Apply the baseline prompt above, plus these explicit review rules:
+
+0. **Be ambitious about structural simplification.**
+   - Do not stop at "this could be a bit cleaner."
+   - Look for opportunities to reframe the change so that whole branches, helpers, modes, conditionals, or layers disappear entirely.
+   - Prefer the solution that makes the code feel inevitable in hindsight.
+   - Assume there is often a "code judo" move available: a re-organization that uses the existing architecture more effectively and makes the change dramatically simpler and more elegant.
+   - If you see a path to delete complexity rather than rearrange it, push hard for that path.
+
+1. **Do not let a PR push a file from under 1k lines to over 1k lines without a very strong reason.**
+   - Treat this as a strong code-quality smell by default.
+   - Prefer extracting helpers, subcomponents, modules, or local abstractions instead of letting a file sprawl past 1000 lines.
+   - If the diff crosses that threshold, explicitly ask whether the code should be decomposed first.
+   - Only waive this if there is a compelling structural reason and the resulting file is still clearly organized.
+
+2. **Do not allow random spaghetti growth in existing code.**
+   - Be highly suspicious of new ad-hoc conditionals, scattered special cases, or one-off branches inserted into unrelated flows.
+   - If a change adds "weird if statements in random places", treat that as a design problem, not a stylistic nit.
+   - Prefer pushing the logic into a dedicated abstraction, helper, state machine, policy object, or separate module instead of tangling an existing path.
+   - Call out changes that make the surrounding code harder to reason about, even if they technically work.
+
+3. **Bias toward cleaning the design, not just accepting working code.**
+   - If behavior can stay the same while the structure becomes meaningfully cleaner, push for the cleaner version.
+   - Do not rubber-stamp "it works" implementations that leave the codebase messier.
+   - Strongly prefer simplifications that remove moving pieces altogether over refactors that merely spread the same complexity around.
+
+4. **Prefer direct, boring, maintainable code over hacky or magical code.**
+   - Treat brittle, ad-hoc, or "magic" behavior as a code-quality problem.
+   - Be skeptical of generic mechanisms that hide simple data-shape assumptions.
+   - Flag thin abstractions, identity wrappers, or pass-through helpers that add indirection without buying clarity.
+
+5. **Push hard on type and boundary cleanliness when they affect maintainability.**
+   - Question unnecessary optionality, `unknown`, `any`, or cast-heavy code when a clearer type boundary could exist.
+   - Prefer explicit typed models or shared contracts over loosely-shaped ad-hoc objects.
+   - If a branch relies on silent fallback to paper over an unclear invariant, ask whether the boundary should be made explicit instead.
+
+6. **Keep logic in the canonical layer and reuse existing helpers.**
+   - Call out feature logic leaking into shared paths or implementation details leaking through APIs.
+   - Prefer existing canonical utilities/helpers over bespoke one-offs.
+   - Push code toward the right package, service, or module instead of normalizing architectural drift.
+
+7. **Treat unnecessary sequential orchestration and non-atomic updates as design smells when the cleaner structure is obvious.**
+   - If independent work is serialized for no good reason, ask whether the flow should run in parallel instead.
+   - If related updates can leave state half-applied, push for a more atomic structure.
+   - Do not over-index on micro-optimizations, but do flag avoidable orchestration complexity that makes the implementation more brittle.
+
+## Primary Review Questions
+
+For every meaningful change, ask:
+
+- Is there a "code judo" move that would make this dramatically simpler?
+- Can this change be reframed so fewer concepts, branches, or helper layers are needed?
+- Does this improve or worsen the local architecture?
+- Did the diff add branching complexity where a better abstraction should exist?
+- Did a previously cohesive module become more coupled, more stateful, or harder to scan?
+- Is this logic living in the right file and layer?
+- Did this change enlarge a file or component past a healthy size boundary?
+- Are there repeated conditionals that signal a missing model or missing helper?
+- Is the implementation direct and legible, or does it rely on special cases and incidental control flow?
+- Is this abstraction actually earning its keep, or is it just a wrapper?
+- Did the diff introduce casts, optionality, or ad-hoc object shapes that obscure the real invariant?
+- Is this logic living in the canonical layer, or did the diff leak details across a boundary?
+- Is this orchestration more sequential or less atomic than it needs to be?
+
+## What to Flag Aggressively
+
+Escalate findings when you see:
+
+- A complicated implementation where a cleaner reframing could delete whole categories of complexity.
+- Refactors that move code around but fail to reduce the number of concepts a reader must hold in their head.
+- A file crossing 1000 lines due to the PR, especially if the new code could be split out.
+- New conditionals bolted onto unrelated code paths.
+- One-off booleans, nullable modes, or flags that complicate existing control flow.
+- Feature-specific logic leaking into general-purpose modules.
+- Generic "magic" handling that hides simple structure and makes the code harder to reason about.
+- Thin wrappers or identity abstractions that add indirection without simplifying anything.
+- Unnecessary casts, `any`, `unknown`, or optional params that muddy the real contract.
+- Copy-pasted logic instead of extracted helpers.
+- Narrow edge-case handling implemented in the middle of an already busy function.
+- Refactors that technically pass tests but make the code less modular or less readable.
+- "Temporary" branching that is likely to become permanent debt.
+- Bespoke helpers where the codebase already has a canonical utility for the job.
+- Logic added in the wrong layer/package when it should live somewhere more central.
+- Sequential async flow where obviously independent work could stay simpler and clearer with parallel execution.
+- Partial-update logic that leaves state less atomic than necessary.
+
+## Preferred Remedies
+
+When you identify a code-quality problem, prefer suggestions like:
+
+- Delete a whole layer of indirection rather than polishing it.
+- Reframe the state model so conditionals disappear instead of getting centralized.
+- Change the ownership boundary so the feature becomes a natural extension of an existing abstraction.
+- Turn special-case logic into a simpler default flow with fewer exceptions.
+- Extract a helper or pure function.
+- Split a large file into smaller focused modules.
+- Move feature-specific logic behind a dedicated abstraction.
+- Replace condition chains with a typed model or explicit dispatcher.
+- Separate orchestration from business logic.
+- Collapse duplicate branches into a single clearer flow.
+- Delete wrappers that do not meaningfully clarify the API.
+- Reuse the existing canonical helper instead of introducing a near-duplicate.
+- Make type boundaries more explicit so the control flow gets simpler.
+- Move the logic to the package/module/layer that already owns the concept.
+- Parallelize independent work when that also simplifies the orchestration.
+- Restructure related updates into a more atomic flow when partial state would be harder to reason about.
+
+Do not be satisfied with "maybe rename this" feedback when the real issue is structural.
+Do not be satisfied with a merely cleaner version of the same messy idea if there is a plausible path to a much simpler idea.
+
+## Review Tone
+
+Be direct, serious, and demanding about quality.
+Do not be rude, but do not soften major maintainability issues into mild suggestions.
+If the code is making the codebase messier, say so clearly.
+If the implementation missed an opportunity for a dramatic simplification, say that clearly too.
+
+Good phrases:
+
+- `this pushes the file past 1k lines. can we decompose this first?`
+- `this adds another special-case branch into an already busy flow. can we move this behind its own abstraction?`
+- `this works, but it makes the surrounding code more spaghetti. let's keep the behavior and restructure the implementation.`
+- `this feels like feature logic leaking into a shared path. can we isolate it?`
+- `this abstraction seems unnecessary. can we just keep the direct flow?`
+- `why does this need a cast / optional here? can we make the boundary more explicit instead?`
+- `this looks like a bespoke helper for something we already have elsewhere. can we reuse the canonical one?`
+- `i think there's a code-judo move here that makes this much simpler. can we reframe this so these branches disappear?`
+- `this refactor moves complexity around, but doesn't really delete it. is there a way to make the model itself simpler?`
+
+## Output Expectations
+
+Prioritize findings in this order:
+
+1. Structural code-quality regressions
+2. Missed opportunities for dramatic simplification / code-judo restructuring
+3. Spaghetti / branching complexity increases
+4. Boundary / abstraction / type-contract problems that make the code harder to reason about
+5. File-size and decomposition concerns
+6. Modularity and abstraction issues
+7. Legibility and maintainability concerns
+
+Do not flood the review with low-value nits if there are larger structural issues.
+Prefer a smaller number of high-conviction comments over a long list of cosmetic notes.
+
+## Approval Bar
+
+Do not approve merely because behavior seems correct.
+The bar for approval is:
+
+- no clear structural regression
+- no obvious missed opportunity to make the implementation dramatically simpler when such a path is visible
+- no unjustified file-size explosion
+- no obvious spaghetti-growth from special-case branching
+- no obviously hacky or magical abstraction that makes the code harder to reason about
+- no unnecessary wrapper/cast/optionality churn obscuring the real design
+- no clear architecture-boundary leak or avoidable canonical-helper duplication
+- no missed opportunity for an obvious decomposition that would materially improve maintainability
+
+Treat these as presumptive blockers unless the author can justify them clearly:
+
+- the PR preserves a lot of incidental complexity when there is a plausible code-judo move that would delete it
+- the PR pushes a file from below 1000 lines to above 1000 lines
+- the PR adds ad-hoc branching that makes an existing flow more tangled
+- the PR solves a local problem by scattering feature checks across shared code
+- the PR adds an unnecessary abstraction, wrapper, or cast-heavy contract that makes the design more indirect
+- the PR duplicates an existing helper or puts logic in the wrong layer when there is a clear canonical home
+
+If those conditions are not met, leave explicit, actionable feedback and push for a cleaner decomposition.

--- a/SPEC.md
+++ b/SPEC.md
@@ -617,6 +617,7 @@ POST /api/chat
 - Request body includes webSearch: { enabled: boolean, contextSize: "low" | "medium" | "high" } and imageGeneration: { enabled, quality, aspectRatio, outputFormat, model }
 - Handles MCP tools, OpenRouter web search (agentic or legacy :online), Chatlima image_generation tool backed by OpenRouter image-output models, native web_fetch, images (base64), file references (Blob URLs)
 - Integrates read_file tool for uploaded documents and web_fetch tool for URL extraction
+- **Persistence**: Client history (excluding in-flight assistant placeholder) is saved before streaming starts; assistant messages are saved in awaited `uiOnFinish` after waiting up to 6s for `streamText` metadata (image URLs, tool steps). `saveMessages` uses a DB transaction (delete + insert). Stream-finish fallback persistence runs via Next.js `after()`.
 ```
 
 #### Upload API

--- a/__tests__/lib/chat-store.test.ts
+++ b/__tests__/lib/chat-store.test.ts
@@ -1,0 +1,68 @@
+import type { UIMessage } from 'ai';
+import { convertToDBMessages } from '@/lib/chat-store';
+
+jest.mock('@/lib/db', () => ({
+  db: {},
+}));
+
+jest.mock('@/app/actions', () => ({
+  generateTitle: jest.fn(),
+}));
+
+describe('chat-store message conversion', () => {
+  it('assigns monotonically increasing createdAt values to preserve array order', () => {
+    const messages: UIMessage[] = [
+      {
+        id: 'user-1',
+        role: 'user',
+        parts: [{ type: 'text', text: 'First prompt' }],
+      },
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'First answer' }],
+      },
+      {
+        id: 'user-2',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Second prompt' }],
+      },
+    ];
+
+    const dbMessages = convertToDBMessages(messages, 'chat-1');
+    const timestamps = dbMessages.map((message) => message.createdAt.getTime());
+
+    expect(dbMessages.map((message) => message.id)).toEqual([
+      'user-1',
+      'assistant-1',
+      'user-2',
+    ]);
+    expect(timestamps[0]).toBeLessThan(timestamps[1]);
+    expect(timestamps[1]).toBeLessThan(timestamps[2]);
+  });
+
+  it('normalizes duplicate existing createdAt values in message order', () => {
+    const sameCreatedAt = '2026-05-31T04:41:47.761Z';
+    const messages = [
+      {
+        id: 'user-1',
+        role: 'user',
+        createdAt: sameCreatedAt,
+        parts: [{ type: 'text', text: 'First prompt' }],
+      },
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        createdAt: sameCreatedAt,
+        parts: [{ type: 'text', text: 'First answer' }],
+      },
+    ] as Array<UIMessage & { createdAt: string }>;
+
+    const dbMessages = convertToDBMessages(messages, 'chat-1');
+
+    expect(dbMessages[0].createdAt.toISOString()).toBe(sameCreatedAt);
+    expect(dbMessages[1].createdAt.getTime()).toBe(
+      dbMessages[0].createdAt.getTime() + 1
+    );
+  });
+});

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -17,7 +17,10 @@ import { parseChatRequestBody } from '@/lib/chat/chatRequest';
 import { createErrorResponse } from '@/lib/chat/createErrorResponse';
 import { runChatPreflight } from '@/lib/chat/chatPreflight';
 import { buildChatStreamPlan } from '@/lib/chat/buildChatStreamPlan';
-import { createChatStreamFinalizer } from '@/lib/chat/chatStreamFinalizer';
+import {
+  createChatStreamFinalizer,
+  persistClientMessagesAtRequestStart,
+} from '@/lib/chat/chatStreamFinalizer';
 import type { OpenRouterStreamResponse } from '@/lib/chat/chatStreamFinalizer';
 
 export { createErrorResponse } from '@/lib/chat/createErrorResponse';
@@ -138,6 +141,18 @@ export async function POST(req: Request) {
     }
     const plan = planResult.plan;
 
+    try {
+      await persistClientMessagesAtRequestStart({
+        chatId,
+        clientMessages: chatBody.messages,
+      });
+    } catch (earlyPersistError) {
+      console.error(
+        `[Chat ${chatId}][requestStart] Failed to persist client messages:`,
+        earlyPersistError
+      );
+    }
+
     const finalizer = createChatStreamFinalizer({
       chatId,
       requestId,
@@ -234,10 +249,12 @@ export async function POST(req: Request) {
     return result.toUIMessageStreamResponse({
       originalMessages: chatBody.messages,
       sendReasoning: true,
-      onFinish: ({ responseMessage }) => {
-        void finalizer.handleUiStreamFinish(responseMessage).catch((err) => {
+      onFinish: async ({ responseMessage }) => {
+        try {
+          await finalizer.handleUiStreamFinish(responseMessage);
+        } catch (err) {
           console.error(`[Chat ${chatId}][uiOnFinish] Unhandled error:`, err);
-        });
+        }
       },
       onError: (error: unknown) => {
         const err = error as {

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,2044 +1,362 @@
-import { streamText, generateText, tool, jsonSchema, stepCountIs, type UIMessage, type LanguageModel, type LanguageModelResponseMetadata } from "ai";
-import { saveChat, saveMessages, convertToDBMessages } from '@/lib/chat-store';
+import { streamText, stepCountIs, type LanguageModel, type ToolSet } from 'ai';
 import { generateTitle } from '@/app/actions';
-import {
-    extractGeneratedImageUrlsFromStreamEvent,
-    getUIMessageText,
-    userMessageRequestsImageCreation,
-} from '@/lib/message-utils';
-import {
-    buildAssistantMessageForPersistence,
-    countPersistableDisplayParts,
-    createStreamFinishGate,
-    processMessagesForPersistence,
-} from '@/lib/chat-message-persistence';
 import { nanoid } from 'nanoid';
-import { db } from '@/lib/db';
-import { chats, messages as messagesTable } from '@/lib/db/schema';
-import { eq, and } from 'drizzle-orm';
-import { trackTokenUsage, hasEnoughCredits, WEB_SEARCH_COST } from '@/lib/tokenCounter';
-import { resolveAllowedImageModel } from '@/lib/constants/image-generation-models';
-import { TokenTrackingService } from '@/lib/tokenTracking';
-import { CostCalculationService } from '@/lib/services/costCalculation';
-import { SimpleCostEstimationService } from '@/lib/services/simpleCostEstimation';
-import { DirectTokenTrackingService } from '@/lib/services/directTokenTracking';
-import { getRemainingCredits, getRemainingCreditsByExternalId, getSubscriptionTypeByExternalId } from '@/lib/polar';
-import { createRequestCreditCache, hasEnoughCreditsWithCache } from '@/lib/services/creditCache';
-import { auth } from '@/lib/auth';
-import { logDiagnostic as originalLogDiagnostic, logChunk, logPerformanceMetrics, logError, logRequestBoundary } from '@/lib/utils/performantLogging';
-import { DailyMessageUsageService } from '@/lib/services/dailyMessageUsageService';
-import { UsageLimitsService } from '@/lib/services/usageLimits';
-import { OptimizedUsageLimitsService } from '@/lib/services/optimizedUsageLimits';
-import type { ImageUIPart } from '@/lib/types';
-import { convertToOpenRouterFormat } from '@/lib/openrouter-utils';
-import { model, type modelID, getLanguageModelWithKeys, createOpenRouterClientWithKey, usesTagBasedReasoningExtraction, wrapWithTagBasedReasoning } from "@/ai/providers";
-import { getModelDetails } from "@/lib/models/fetch-models";
-import { type ModelInfo } from "@/lib/types/models";
-import { createOpenRouter } from "@openrouter/ai-sdk-provider";
-import { getApiKey } from "@/ai/providers";
-import { validatePresetParameters, getModelDefaults, sanitizeSystemInstruction } from "@/lib/parameter-validation";
-import { cleanToolsForGoogleModels, isGoogleModel } from '@/lib/google-model-tools';
-import { z } from "zod";
-import { parseFile } from "@/lib/file-reader";
-import { fetchFileContent } from "@/lib/file-upload";
-import { startBackgroundStreamConsumption } from "@/lib/chat-stream-consumption";
-import { registerChatAbortController, abortChatGeneration } from "@/lib/chat-stop-registry";
-
-// Import our new services
-import { ChatAuthenticationService, ChatAuthenticationError, type AuthenticatedUser } from '@/lib/services/chatAuthenticationService';
+import { createRequestCreditCache } from '@/lib/services/creditCache';
 import {
-    ChatCreditValidationService,
-    type CreditValidationContext,
-    type CreditValidationResult,
-    CreditValidationError,
-    InsufficientCreditsError,
-    FeatureRestrictedError,
-    FreeModelOnlyError,
-    PremiumModelRestrictedError
-} from '@/lib/services/chatCreditValidationService';
-import { ChatMessageProcessingService, type MessageProcessingContext } from '@/lib/services/chatMessageProcessingService';
-import { ChatModelValidationService, type ModelValidationContext, type ModelValidationResult } from '@/lib/services/chatModelValidationService';
-import { ChatMCPServerService, type MCPServerContext, type MCPServerResult } from '@/lib/services/chatMCPServerService';
-import { ChatWebSearchService, type WebSearchContext, type WebSearchResult } from '@/lib/services/chatWebSearchService';
-import { ChatImageGenerationService, type ImageGenerationOptions } from '@/lib/services/chatImageGenerationService';
-import { resolveOpenRouterWebSearchRouteSetup } from '@/lib/services/openRouterWebSearchRouteSetup';
-import { ChatTokenTrackingService, type TokenTrackingContext, type TokenTrackingResult } from '@/lib/services/chatTokenTrackingService';
-import { ChatDatabaseService, type ChatCreationContext, type MessageSavingContext } from '@/lib/services/chatDatabaseService';
-import { buildProjectContext, formatProjectContextForSystemPrompt } from '@/lib/services/projectContext';
-import { WebFetchService, WebFetchError } from '@/lib/services/webFetchService';
-import { getAccessPolicyFlags } from '@/lib/config/access-policy';
-import { canUserChat, hasProviderByokForModel } from '@/lib/services/accessGateService';
+  logDiagnostic as originalLogDiagnostic,
+  logChunk,
+  logRequestBoundary,
+} from '@/lib/utils/performantLogging';
+import { startBackgroundStreamConsumption } from '@/lib/chat-stream-consumption';
+import { registerChatAbortController, abortChatGeneration } from '@/lib/chat-stop-registry';
+import { ChatAuthenticationService, ChatAuthenticationError } from '@/lib/services/chatAuthenticationService';
+import { CreditValidationError } from '@/lib/services/chatCreditValidationService';
+import { ChatMCPServerService } from '@/lib/services/chatMCPServerService';
+import { ChatDatabaseService } from '@/lib/services/chatDatabaseService';
+import { parseChatRequestBody } from '@/lib/chat/chatRequest';
+import { createErrorResponse } from '@/lib/chat/createErrorResponse';
+import { runChatPreflight } from '@/lib/chat/chatPreflight';
+import { buildChatStreamPlan } from '@/lib/chat/buildChatStreamPlan';
+import { createChatStreamFinalizer } from '@/lib/chat/chatStreamFinalizer';
+import type { OpenRouterStreamResponse } from '@/lib/chat/chatStreamFinalizer';
 
-// Use optimized logging - only logs in development and uses efficient patterns
+export { createErrorResponse } from '@/lib/chat/createErrorResponse';
+
 const logDiagnostic = originalLogDiagnostic;
 
-// Allow streaming responses up to 300 seconds on Hobby plan
 export const maxDuration = 300;
 
-// Helper function to check if user is using their own API keys for the selected model
-function checkIfUsingOwnApiKeys(selectedModel: string, apiKeys: Record<string, string> = {}): boolean {
-    return hasProviderByokForModel(selectedModel, apiKeys);
-}
-
-interface KeyValuePair {
-    key: string;
-    value: string;
-}
-
-interface MCPServerConfig {
-    url: string;
-    type: 'sse' | 'stdio' | 'streamable-http';
-    command?: string;
-    args?: string[];
-    env?: KeyValuePair[];
-    headers?: KeyValuePair[];
-    useOAuth?: boolean;
-    id?: string;
-    oauthTokens?: {
-        access_token: string;
-        refresh_token?: string;
-        expires_in?: number;
-        token_type?: string;
-    };
-}
-
-interface WebSearchOptions {
-    enabled: boolean;
-    contextSize: 'low' | 'medium' | 'high';
-}
-
-interface ImageGenerationRequestOptions {
-    enabled: boolean;
-    quality?: ImageGenerationOptions['quality'];
-    aspectRatio?: string;
-    outputFormat?: ImageGenerationOptions['outputFormat'];
-    model?: string;
-}
-
-interface UrlCitation {
-    url: string;
-    title: string;
-    content?: string;
-    start_index: number;
-    end_index: number;
-}
-
-interface Annotation {
-    type: string;
-    url_citation: UrlCitation;
-}
-
-interface OpenRouterResponse extends LanguageModelResponseMetadata {
-    readonly messages: Array<UIMessage | { role: string; content?: string | unknown[]; parts?: unknown[]; id?: string }>;
-    annotations?: Annotation[];
-    body?: unknown;
-}
-
-// Helper to create standardized error responses
-export const createErrorResponse = (
-    code: string,
-    message: string,
-    status: number,
-    details?: string
-) => {
-    return new Response(
-        JSON.stringify({ error: { code, message, details } }),
-        { status, headers: { "Content-Type": "application/json" } }
-    );
-};
-
-// Helper to extract input tokens from event (AI SDK format)
-const extractInputTokensFromEvent = (event: any): number => {
-    if (!event) return 0;
-
-    console.log(`[DEBUG] Extracting input tokens from event:`, {
-        hasUsage: !!event.usage,
-        hasResponseUsage: !!event.response?.usage,
-        usageKeys: event.usage ? Object.keys(event.usage) : [],
-        responseUsageKeys: event.response?.usage ? Object.keys(event.response.usage) : [],
-        eventKeys: Object.keys(event),
-        usage: event.usage,
-        responseUsage: event.response?.usage
-    });
-
-    const isValidToken = (value: any): boolean => {
-        return typeof value === 'number' && !isNaN(value) && value > 0;
-    };
-
-    const isRequestyWithInvalidTokens = (event: any): boolean => {
-        if (!event) return false;
-
-        const hasNaNTokens = (
-            (event.usage && (
-                (typeof event.usage.promptTokens === 'number' && isNaN(event.usage.promptTokens)) ||
-                (typeof event.usage.completionTokens === 'number' && isNaN(event.usage.completionTokens))
-            )) ||
-            (event.response?.usage && (
-                (typeof event.response.usage.promptTokens === 'number' && isNaN(event.response.usage.promptTokens)) ||
-                (typeof event.response.usage.completionTokens === 'number' && isNaN(event.response.usage.completionTokens))
-            ))
-        );
-
-        return hasNaNTokens;
-    };
-
-    const extractFromUsage = (usage: any, source: string): number | null => {
-        if (!usage) return null;
-
-        if (isValidToken(usage.promptTokens)) {
-            console.log(`[DEBUG] Found input tokens in ${source}.promptTokens: ${usage.promptTokens}`);
-            return usage.promptTokens;
-        }
-        if (isValidToken(usage.inputTokens)) {
-            console.log(`[DEBUG] Found input tokens in ${source}.inputTokens: ${usage.inputTokens}`);
-            return usage.inputTokens;
-        }
-        if (isValidToken(usage.prompt_tokens)) {
-            console.log(`[DEBUG] Found input tokens in ${source}.prompt_tokens: ${usage.prompt_tokens}`);
-            return usage.prompt_tokens;
-        }
-        if (isValidToken(usage.input_tokens)) {
-            console.log(`[DEBUG] Found input tokens in ${source}.input_tokens: ${usage.input_tokens}`);
-            return usage.input_tokens;
-        }
-
-        if (usage.promptTokens !== undefined || usage.inputTokens !== undefined ||
-            usage.prompt_tokens !== undefined || usage.input_tokens !== undefined) {
-            console.log(`[DEBUG] Found usage data in ${source} but values are invalid:`, {
-                promptTokens: usage.promptTokens,
-                inputTokens: usage.inputTokens,
-                prompt_tokens: usage.prompt_tokens,
-                input_tokens: usage.input_tokens
-            });
-        }
-
-        return null;
-    };
-
-    let tokens = extractFromUsage(event.usage, 'event.usage');
-    if (tokens !== null) return tokens;
-
-    tokens = extractFromUsage(event.response?.usage, 'event.response.usage');
-    if (tokens !== null) return tokens;
-
-    if (isValidToken(event.promptTokens)) {
-        console.log(`[DEBUG] Found input tokens in event.promptTokens: ${event.promptTokens}`);
-        return event.promptTokens;
-    }
-    if (isValidToken(event.inputTokens)) {
-        console.log(`[DEBUG] Found input tokens in event.inputTokens: ${event.inputTokens}`);
-        return event.inputTokens;
-    }
-
-    if (isValidToken(event.response?.promptTokens)) {
-        console.log(`[DEBUG] Found input tokens in event.response.promptTokens: ${event.response.promptTokens}`);
-        return event.response.promptTokens;
-    }
-    if (isValidToken(event.response?.inputTokens)) {
-        console.log(`[DEBUG] Found input tokens in event.response.inputTokens: ${event.response.inputTokens}`);
-        return event.response.inputTokens;
-    }
-
-    if (event.response && typeof event.response === 'object') {
-        console.log(`[DEBUG] Checking event.response for nested token data:`, {
-            responseKeys: Object.keys(event.response),
-            hasUsage: !!event.response.usage,
-            hasResult: !!event.response.result,
-            hasData: !!event.response.data,
-            hasMetadata: !!event.response.metadata
-        });
-
-        const possiblePaths = [
-            event.response.usage,
-            event.response.result?.usage,
-            event.response.data?.usage,
-            event.response.metadata?.usage
-        ];
-
-        for (const pathUsage of possiblePaths) {
-            if (pathUsage) {
-                const pathTokens = extractFromUsage(pathUsage, 'event.response nested');
-                if (pathTokens !== null) return pathTokens;
-            }
-        }
-    }
-
-    if (event.steps && Array.isArray(event.steps)) {
-        console.log(`[DEBUG] Checking event.steps for token data:`, {
-            stepsCount: event.steps.length,
-            firstStepKeys: event.steps[0] ? Object.keys(event.steps[0]) : []
-        });
-
-        // Aggregate tokens from all steps (important for tool calls)
-        let totalStepInputTokens = 0;
-        let totalStepOutputTokens = 0;
-        let hasStepTokens = false;
-
-        for (let i = 0; i < event.steps.length; i++) {
-            const step = event.steps[i];
-            if (step && step.usage) {
-                const stepUsage = step.usage as any;
-                const stepInputTokens = stepUsage.promptTokens || stepUsage.inputTokens || stepUsage.prompt_tokens || stepUsage.input_tokens || 0;
-                const stepOutputTokens = stepUsage.completionTokens || stepUsage.outputTokens || stepUsage.completion_tokens || stepUsage.output_tokens || 0;
-
-                if (stepInputTokens > 0 || stepOutputTokens > 0) {
-                    totalStepInputTokens += stepInputTokens;
-                    totalStepOutputTokens += stepOutputTokens;
-                    hasStepTokens = true;
-                    console.log(`[DEBUG] Step ${i} tokens: input=${stepInputTokens}, output=${stepOutputTokens}`);
-                }
-            }
-        }
-
-        if (hasStepTokens) {
-            console.log(`[DEBUG] Aggregated step tokens: input=${totalStepInputTokens}, output=${totalStepOutputTokens}`);
-            // Return the total from all steps if we found any tokens
-            if (totalStepInputTokens > 0) return totalStepInputTokens;
-            // If no input tokens but output tokens exist, we still have valid data
-            if (totalStepOutputTokens > 0) return 0; // Return 0 for input, but indicate we found tokens
-        }
-    }
-
-    if (event.request && typeof event.request === 'object') {
-        console.log(`[DEBUG] Checking event.request for token data:`, {
-            requestKeys: Object.keys(event.request),
-            hasUsage: !!event.request.usage
-        });
-
-        if (event.request.usage) {
-            const requestTokens = extractFromUsage(event.request.usage, 'event.request.usage');
-            if (requestTokens !== null) return requestTokens;
-        }
-    }
-
-    console.log(`[DEBUG] Searching entire event object for token data as last resort`);
-    const searchForTokens = (obj: any, path: string): number | null => {
-        if (!obj || typeof obj !== 'object') return null;
-
-        if (obj.promptTokens || obj.inputTokens || obj.prompt_tokens || obj.input_tokens) {
-            const tokens = extractFromUsage(obj, path);
-            if (tokens !== null) return tokens;
-        }
-
-        if (path.split('.').length < 4) {
-            for (const [key, value] of Object.entries(obj)) {
-                if (typeof value === 'object' && value !== null) {
-                    const found = searchForTokens(value, `${path}.${key}`);
-                    if (found !== null) return found;
-                }
-            }
-        }
-
-        return null;
-    };
-
-    const foundTokens = searchForTokens(event, 'event');
-    if (foundTokens !== null) return foundTokens;
-
-    if (isRequestyWithInvalidTokens(event)) {
-        console.log(`[DEBUG] Detected Requesty model with NaN token values - applying estimation fallback`);
-
-        let estimatedTokens = 0;
-
-        const textContent = event.text || '';
-        const systemInstructionLength = 1673;
-
-        if (textContent || event.response?.messages?.length > 0) {
-            const totalInputChars = systemInstructionLength + (textContent.length || 0);
-            estimatedTokens = Math.round(totalInputChars / 4);
-
-            console.log(`[DEBUG] Requesty fallback estimation: ${estimatedTokens} tokens (based on ${totalInputChars} chars)`);
-        } else {
-            estimatedTokens = Math.round(systemInstructionLength / 4);
-            console.log(`[DEBUG] Requesty minimal fallback estimation: ${estimatedTokens} tokens`);
-        }
-
-        return estimatedTokens > 0 ? estimatedTokens : 0;
-    }
-
-    console.log(`[DEBUG] No input tokens found in event or event.response, returning 0`);
-    return 0;
-};
-
 export async function POST(req: Request) {
-    const requestId = nanoid();
-    const requestStartTime = Date.now();
+  const requestId = nanoid();
+  const requestStartTime = Date.now();
 
-    // Create request-scoped caches for performance optimization
-    const { getRemainingCreditsByExternalId: getCachedCreditsByExternal, getRemainingCredits: getCachedCredits, cache: creditCache } = createRequestCreditCache();
+  const { getRemainingCreditsByExternalId: getCachedCreditsByExternal } =
+    createRequestCreditCache();
 
-    // Enhanced timing tracking variables
-    let firstTokenTime: number | null = null;
-    let streamingStartTime: Date | null = null;
-    let timeToFirstTokenMs: number | null = null;
-    let tokensPerSecond: number | null = null;
+  logRequestBoundary('START', requestId, {
+    url: req.url,
+    method: req.method,
+    startTime: requestStartTime,
+  });
 
-    logRequestBoundary('START', requestId, {
-        url: req.url,
-        method: req.method,
-        startTime: requestStartTime
+  try {
+    const body = await req.json();
+
+    if (body?.action === 'stop') {
+      const authenticatedUser = await ChatAuthenticationService.authenticateUser(req);
+      const stopChatId = typeof body?.chatId === 'string' ? body.chatId : '';
+
+      if (!stopChatId) {
+        return createErrorResponse(
+          'INVALID_REQUEST',
+          'chatId is required to stop generation.',
+          400
+        );
+      }
+
+      const stopped = abortChatGeneration(authenticatedUser.userId, stopChatId);
+      return Response.json({ ok: true, stopped, chatId: stopChatId });
+    }
+
+    const chatBody = parseChatRequestBody(body);
+
+    logDiagnostic('REQUEST_PARSED', 'Request body parsed', {
+      requestId,
+      messagesCount: chatBody.messages.length,
+      chatId: chatBody.chatId,
+      selectedModel: chatBody.selectedModel,
+      attachmentsCount: chatBody.attachments.length,
+      webSearchEnabled: chatBody.webSearch.enabled,
+      imageGenerationEnabled: chatBody.imageGeneration.enabled,
+      hasTemperature: chatBody.temperature !== undefined,
+      hasMaxTokens: chatBody.maxTokens !== undefined,
+      hasSystemInstruction: chatBody.systemInstruction !== undefined,
     });
 
-    try {
-        const body = await req.json();
-        const action = body?.action;
-
-        if (action === 'stop') {
-            const authenticatedUser = await ChatAuthenticationService.authenticateUser(req);
-            const stopChatId = typeof body?.chatId === 'string' ? body.chatId : '';
-
-            if (!stopChatId) {
-                return createErrorResponse(
-                    'INVALID_REQUEST',
-                    'chatId is required to stop generation.',
-                    400
-                );
-            }
-
-            const stopped = abortChatGeneration(authenticatedUser.userId, stopChatId);
-            return Response.json({ ok: true, stopped, chatId: stopChatId });
-        }
-
-        // Parse request body
-        const {
-            messages,
-            chatId,
-            selectedModel,
-            mcpServers: initialMcpServers = [],
-            webSearch = { enabled: false, contextSize: 'medium' },
-            imageGeneration = {
-                enabled: false,
-                quality: 'medium' as const,
-                aspectRatio: '1:1',
-                outputFormat: 'png' as const,
-                model: 'openai/gpt-5-image',
-            },
-            apiKeys = {},
-            attachments = [],
-            temperature,
-            maxTokens,
-            systemInstruction
-        }: {
-            messages: UIMessage[];
-            chatId?: string;
-            selectedModel: string;
-            mcpServers?: MCPServerConfig[];
-            webSearch?: WebSearchOptions;
-            imageGeneration?: ImageGenerationRequestOptions;
-            apiKeys?: Record<string, string>;
-            attachments?: Array<{
-                name: string;
-                contentType: string;
-                url: string;
-            }>;
-            temperature?: number;
-            maxTokens?: number;
-            systemInstruction?: string;
-        } = body;
-
-        logDiagnostic('REQUEST_PARSED', `Request body parsed`, {
-            requestId,
-            messagesCount: messages.length,
-            chatId,
-            selectedModel,
-            attachmentsCount: attachments.length,
-            webSearchEnabled: webSearch.enabled,
-            imageGenerationEnabled: imageGeneration.enabled,
-            hasTemperature: temperature !== undefined,
-            hasMaxTokens: maxTokens !== undefined,
-            hasSystemInstruction: systemInstruction !== undefined
-        });
-
-        // 1. Authenticate user
-        const authenticatedUser = await ChatAuthenticationService.authenticateUser(req);
-
-        // 2. Validate model and get configuration
-        const modelValidation = await ChatModelValidationService.validateAndConfigureModel({
-            selectedModel,
-            temperature,
-            maxTokens,
-            systemInstruction
-        });
-
-        // 3. Process messages with attachments
-        const processedMessages = await ChatMessageProcessingService.processMessagesWithAttachments({
-            messages,
-            attachments,
-            modelInfo: modelValidation.modelInfo
-        });
-
-        // 4. Add model-specific instructions
-        const modelMessages = ChatMessageProcessingService.addModelSpecificInstructions(
-            processedMessages.messages,
-            selectedModel
-        );
-
-        const accessPolicyFlags = getAccessPolicyFlags();
-        let hasPaidSubscription = false;
-
-        if (!authenticatedUser.isAnonymous) {
-            try {
-                const subscriptionType = await getSubscriptionTypeByExternalId(authenticatedUser.userId);
-                hasPaidSubscription = subscriptionType === 'monthly' || subscriptionType === 'yearly';
-            } catch (error) {
-                console.warn('[AccessGate] Failed to resolve subscription type, treating as unsubscribed:', error);
-            }
-        }
-
-        const gateResult = canUserChat({
-            isAnonymous: authenticatedUser.isAnonymous,
-            hasPaidSubscription,
-            selectedModel,
-            apiKeys,
-            flags: accessPolicyFlags
-        });
-
-        if (!gateResult.allowed) {
-            console.warn('[AccessGate] Chat request blocked', {
-                reason: gateResult.reason,
-                userId: authenticatedUser.userId,
-                isAnonymous: authenticatedUser.isAnonymous,
-                selectedModel
-            });
-            return createErrorResponse(
-                gateResult.reason,
-                gateResult.reason === 'PAYWALL_BYOK_REQUIRED'
-                    ? "Paid subscription required, or add a BYOK API key for this model's provider."
-                    : "Paid subscription required to chat.",
-                402
-            );
-        }
-
-        // 5. Validate credits and permissions
-        const creditValidation = await ChatCreditValidationService.validateCredits({
-            userId: authenticatedUser.userId,
-            isAnonymous: authenticatedUser.isAnonymous,
-            polarCustomerId: authenticatedUser.polarCustomerId,
-            selectedModel,
-            isUsingOwnApiKeys: checkIfUsingOwnApiKeys(selectedModel, apiKeys),
-            isFreeModel: selectedModel.endsWith(':free'),
-            webSearchEnabled: webSearch.enabled,
-            estimatedTokens: 30 // Basic estimate
-        });
-
-        // 5a. Check and increment daily message usage for users without credits (using free daily messages)
-        // Users with credits are using credits instead, so don't check/increment daily usage
-        if (!accessPolicyFlags.billingEnforced && !creditValidation.hasCredits) {
-            // First, check if the user has reached their daily limit BEFORE incrementing
-            const limitCheck = await DailyMessageUsageService.checkDailyLimit(
-                authenticatedUser.userId
-            );
-
-            if (limitCheck.hasReachedLimit) {
-                console.log(`[Chat] Daily message limit reached:`, {
-                    userId: authenticatedUser.userId,
-                    isAnonymous: authenticatedUser.isAnonymous,
-                    messageCount: limitCheck.messageCount,
-                    limit: limitCheck.limit,
-                    remaining: limitCheck.remaining
-                });
-                return createErrorResponse(
-                    "MESSAGE_LIMIT_REACHED",
-                    "Message limit reached",
-                    429,
-                    JSON.stringify({
-                        limit: limitCheck.limit,
-                        remaining: limitCheck.remaining,
-                        messageCount: limitCheck.messageCount
-                    })
-                );
-            }
-
-            // Only increment if limit hasn't been reached
-            try {
-                const incrementResult = await DailyMessageUsageService.incrementDailyUsage(
-                    authenticatedUser.userId,
-                    authenticatedUser.isAnonymous
-                );
-                console.log(`[Chat] Incremented daily message usage:`, {
-                    userId: authenticatedUser.userId,
-                    isAnonymous: authenticatedUser.isAnonymous,
-                    newCount: incrementResult.newCount,
-                    date: incrementResult.date,
-                    remaining: limitCheck.remaining - 1
-                });
-            } catch (error) {
-                console.error(`[Chat] Failed to increment daily usage:`, error);
-                // Don't block the request if incrementing fails (but log it)
-            }
-        } else {
-            console.log(`[Chat] Skipping daily usage increment - user has credits (${creditValidation.actualCredits})`);
-        }
-
-        // 6. Validate free model and premium model access
-        await ChatCreditValidationService.validateFreeModelAccess({
-            userId: authenticatedUser.userId,
-            isAnonymous: authenticatedUser.isAnonymous,
-            polarCustomerId: authenticatedUser.polarCustomerId,
-            selectedModel,
-            isUsingOwnApiKeys: checkIfUsingOwnApiKeys(selectedModel, apiKeys),
-            isFreeModel: selectedModel.endsWith(':free'),
-            webSearchEnabled: webSearch.enabled,
-            estimatedTokens: 30,
-            hasCredits: creditValidation.hasCredits
-        });
-
-        await ChatCreditValidationService.validatePremiumModelAccess({
-            userId: authenticatedUser.userId,
-            isAnonymous: authenticatedUser.isAnonymous,
-            polarCustomerId: authenticatedUser.polarCustomerId,
-            selectedModel,
-            isUsingOwnApiKeys: checkIfUsingOwnApiKeys(selectedModel, apiKeys),
-            isFreeModel: selectedModel.endsWith(':free'),
-            webSearchEnabled: webSearch.enabled,
-            estimatedTokens: 30,
-            hasCredits: creditValidation.hasCredits
-        });
-
-        // 7. Configure web search
-        const webSearchConfig = ChatWebSearchService.validateAndConfigureWebSearch({
-            webSearch,
-            selectedModel,
-            isUsingOwnApiKeys: checkIfUsingOwnApiKeys(selectedModel, apiKeys),
-            isAnonymous: authenticatedUser.isAnonymous,
-            actualCredits: creditValidation.actualCredits,
-            modelInfo: modelValidation.modelInfo
-        }, {
-            agenticWebToolsEnabled: accessPolicyFlags.openrouterAgenticWebToolsEnabled,
-        });
-
-        const resolvedImageGenerationModel = resolveAllowedImageModel(imageGeneration.model);
-
-        const imageGenerationConfig = ChatImageGenerationService.validateAndConfigureImageGeneration({
-            imageGeneration: {
-                enabled: imageGeneration.enabled,
-                quality: imageGeneration.quality ?? 'medium',
-                aspectRatio: imageGeneration.aspectRatio ?? '1:1',
-                outputFormat: imageGeneration.outputFormat ?? 'png',
-                model: resolvedImageGenerationModel,
-            },
-            selectedModel,
-            isUsingOwnApiKeys: checkIfUsingOwnApiKeys(selectedModel, apiKeys),
-            isAnonymous: authenticatedUser.isAnonymous,
-            actualCredits: creditValidation.actualCredits,
-            modelInfo: modelValidation.modelInfo,
-        });
-
-        try {
-            ChatImageGenerationService.validateImageGenerationRequest({
-                imageGeneration: {
-                    enabled: imageGeneration.enabled,
-                    quality: imageGeneration.quality ?? 'medium',
-                    aspectRatio: imageGeneration.aspectRatio ?? '1:1',
-                    outputFormat: imageGeneration.outputFormat ?? 'png',
-                    model: resolvedImageGenerationModel,
-                },
-                selectedModel,
-                isUsingOwnApiKeys: checkIfUsingOwnApiKeys(selectedModel, apiKeys),
-                isAnonymous: authenticatedUser.isAnonymous,
-                actualCredits: creditValidation.actualCredits,
-                modelInfo: modelValidation.modelInfo,
-            });
-        } catch (error) {
-            const message = error instanceof Error ? error.message : 'Image generation is not available.';
-            return createErrorResponse('FEATURE_RESTRICTED', message, 403);
-        }
-
-        // 8. Initialize MCP servers
-        const mcpResult = await ChatMCPServerService.initializeMCPServers({
-            mcpServers: initialMcpServers,
-            selectedModel
-        });
-
-        // Register cleanup for MCP clients
-        if (mcpResult.cleanup) {
-            req.signal.addEventListener('abort', async () => {
-                await mcpResult.cleanup();
-            });
-        }
-
-        // 9. Prepare chat ID
-        const id = chatId || nanoid();
-        const streamAbortController = new AbortController();
-        registerChatAbortController(authenticatedUser.userId, id, streamAbortController);
-        const isNewChat = !chatId || !(await ChatDatabaseService.checkChatExists({
-            chatId: id,
-            userId: authenticatedUser.userId
-        }));
-
-        // 10. Pre-emptively create chat if new
-        if (isNewChat) {
-            await ChatDatabaseService.createChatIfNotExists({
-                id,
-                userId: authenticatedUser.userId,
-                selectedModel,
-                apiKeys,
-                isAnonymous: authenticatedUser.isAnonymous,
-                messages: []
-            });
-        }
-
-        // Start title generation in parallel with streaming so it is ready when the response finishes
-        const titleGenerationPromise = isNewChat && (messages as UIMessage[]).some((m) => m.role === 'user')
-            ? generateTitle(
-                messages as UIMessage[],
-                selectedModel,
-                apiKeys,
-                authenticatedUser.userId,
-                authenticatedUser.isAnonymous
-            )
-            : undefined;
-
-        // Continue with the rest of the implementation from the original route.ts
-        // This is where the actual streaming logic begins
-
-        // Get model info for validation and defaults
-        const selectedModelInfo = modelValidation.modelInfo;
-
-        // Process attachments into message parts
-        async function processMessagesWithAttachments(
-            messages: UIMessage[],
-            attachments: Array<{ name: string; contentType: string; url: string }>,
-            modelInfo: any
-        ): Promise<UIMessage[]> {
-            console.log('[DEBUG] processMessagesWithAttachments called with:', {
-                messagesCount: messages.length,
-                attachmentsCount: attachments.length
-            });
-
-            if (attachments.length === 0) {
-                console.log('[DEBUG] No attachments, returning original messages');
-                return messages;
-            }
-
-            // Check if model supports vision
-            const supportsVision = modelInfo?.vision === true;
-            console.log('[DEBUG] Model vision support check:', {
-                selectedModel,
-                supportsVision
-            });
-
-            if (!supportsVision) {
-                console.error('[ERROR] Model does not support vision:', selectedModel);
-                throw new Error(`Selected model ${selectedModel} does not support image inputs. Please choose a vision-capable model.`);
-            }
-
-            // Add attachments to the last user message
-            const processedMessages = [...messages];
-            const lastMessageIndex = processedMessages.length - 1;
-
-            console.log('[DEBUG] Processing attachments for message at index:', lastMessageIndex);
-
-            if (lastMessageIndex >= 0 && processedMessages[lastMessageIndex].role === 'user') {
-                const lastMessage = processedMessages[lastMessageIndex];
-                console.log('[DEBUG] Last message:', {
-                    role: lastMessage.role,
-                    content: getUIMessageText(lastMessage).substring(0, 100),
-                    hasExistingParts: !!lastMessage.parts,
-                    existingPartsCount: lastMessage.parts?.length || 0
-                });
-
-                // Convert attachments to image parts
-                const imageParts: any[] = attachments.map((attachment, index) => {
-                    console.log('[DEBUG] Converting attachment', index, ':', {
-                        name: attachment.name,
-                        contentType: attachment.contentType,
-                        urlLength: attachment.url.length,
-                        isValidDataUrl: attachment.url.startsWith('data:image/')
-                    });
-
-                    return {
-                        type: 'image_url' as const,
-                        image_url: {
-                            url: attachment.url,
-                            detail: 'auto' as const
-                        },
-                        metadata: {
-                            filename: attachment.name,
-                            mimeType: attachment.contentType,
-                            size: 0,
-                            width: 0,
-                            height: 0
-                        }
-                    };
-                });
-
-                console.log('[DEBUG] Created image parts:', imageParts.length);
-
-                // Create new parts array with type assertion
-                const existingParts = lastMessage.parts?.length
-                    ? lastMessage.parts
-                    : [{ type: 'text', text: getUIMessageText(lastMessage) }];
-                const newParts = [...existingParts, ...imageParts] as any;
-
-                console.log('[DEBUG] Combined parts:', {
-                    existingPartsCount: existingParts.length,
-                    newImagePartsCount: imageParts.length,
-                    totalPartsCount: newParts.length
-                });
-
-                processedMessages[lastMessageIndex] = {
-                    ...lastMessage,
-                    parts: newParts
-                };
-
-                console.log('[DEBUG] Updated last message with image parts');
-            } else {
-                console.warn('[WARN] No user message found to attach images to, or last message is not from user');
-            }
-
-            console.log('[DEBUG] Returning processed messages with attachments');
-            return processedMessages;
-        }
-
-        // Process messages with attachments
-        const processedMessagesWithAttachments = await processMessagesWithAttachments(messages, attachments, selectedModelInfo);
-
-        // Prepare messages for the model
-        const modelMessagesFinal: UIMessage[] = [...processedMessagesWithAttachments];
-
-        if (
-            selectedModel === "openrouter/deepseek/deepseek-r1" ||
-            selectedModel === "openrouter/deepseek/deepseek-r1-0528" ||
-            selectedModel === "openrouter/deepseek/deepseek-r1-0528-qwen3-8b" ||
-            selectedModel === "openrouter/x-ai/grok-3-beta" ||
-            selectedModel === "openrouter/x-ai/grok-3-mini-beta" ||
-            selectedModel === "openrouter/x-ai/grok-3-mini-beta-reasoning-high" ||
-            selectedModel === "openrouter/qwen/qwq-32b"
-        ) {
-            const systemContent = "Please provide your reasoning within <think> tags. After closing the </think> tag, provide your final answer directly without any other special tags.";
-            modelMessagesFinal.unshift({
-                role: "system",
-                id: nanoid(),
-                parts: [{ type: "text", text: systemContent }]
-            });
-        }
-
-        // Use tools from MCP service
-        const tools = mcpResult.tools;
-
-        // Build a lookup from the user-visible attached files section:
-        // "- name | filepath: uploads/... | url: https://..."
-        const attachedFileUrlByPath = new Map<string, string>();
-        for (const msg of messages) {
-            if (msg.role !== 'user') continue;
-            const messageText = getUIMessageText(msg);
-            if (!messageText) continue;
-            const lines = messageText.split('\n');
-            for (const line of lines) {
-                const match = line.match(/filepath:\s*([^\s|]+)\s*\|\s*url:\s*(https?:\/\/\S+)/i);
-                if (match) {
-                    const filepath = match[1].trim();
-                    const fileUrl = match[2].trim();
-                    attachedFileUrlByPath.set(filepath, fileUrl);
-                }
-            }
-        }
-
-        // Add read_file tool for file analysis
-        const read_file = tool({
-            description: `Read contents of a file uploaded by the user. Supports: CSV, Excel, PDF, text files, code files. Returns parsed content based on file type.`,
-            inputSchema: z.object({
-                filepath: z.string().describe('File path or full URL (e.g., "uploads/data-2024-02-06-143022.csv" or "https://...")'),
-            }),
-            execute: async ({ filepath }) => {
-                try {
-                    const rawPath = (filepath || '').trim();
-                    const normalizedPath = rawPath.startsWith('://')
-                        ? `https${rawPath}`
-                        : rawPath.startsWith('//')
-                            ? `https:${rawPath}`
-                            : rawPath;
-
-                    const isFullUrl = /^https?:\/\//i.test(normalizedPath);
-                    const blobBaseUrl = process.env.BLOB_PUBLIC_URL || process.env.NEXT_PUBLIC_BLOB_URL;
-                    const mappedUrl = attachedFileUrlByPath.get(rawPath) || attachedFileUrlByPath.get(normalizedPath);
-                    const projectMappedUrl = projectFileUrlByPath.get(rawPath) || projectFileUrlByPath.get(normalizedPath);
-                    const blobUrl = isFullUrl
-                        ? normalizedPath
-                        : mappedUrl
-                            ? mappedUrl
-                            : projectMappedUrl
-                                ? projectMappedUrl
-                                : blobBaseUrl
-                                    ? `${blobBaseUrl.replace(/\/$/, '')}/${normalizedPath.replace(/^\//, '')}`
-                                    : normalizedPath;
-
-                    if (!/^https?:\/\//i.test(blobUrl)) {
-                        return JSON.stringify({
-                            success: false,
-                            error: 'Invalid file reference. Expected an absolute URL or a filepath with BLOB_PUBLIC_URL configured.'
-                        });
-                    }
-
-                    const result = await fetchFileContent(blobUrl);
-                    if (!result.success || !result.content) {
-                        return JSON.stringify({ success: false, error: result.error || 'Failed to fetch file' });
-                    }
-
-                    const buffer = Buffer.from(result.content);
-                    const cleanPath = (result.finalUrl || filepath).split('?')[0].split('#')[0];
-                    const filename = cleanPath.split('/').pop() || filepath;
-                    const responseMimeType = result.contentType?.split(';')[0]?.trim();
-                    const parseResult = await parseFile(buffer, filename, responseMimeType);
-
-                    if (!parseResult.success) {
-                        return JSON.stringify({ success: false, error: parseResult.error || 'Failed to parse file' });
-                    }
-
-                    return JSON.stringify({ success: true, content: parseResult.content }, null, 2);
-                } catch (error) {
-                    const message = error instanceof Error ? error.message : 'Unknown error';
-                    console.error('[read_file] Error:', error);
-                    return JSON.stringify({ success: false, error: message });
-                }
-            },
-        });
-
-        const webFetchPolicy = {
-            ...WebFetchService.getDefaultPolicy(),
-            enabled: accessPolicyFlags.nativeWebFetchEnabled,
-            defaultMaxChars: accessPolicyFlags.nativeWebFetchMaxChars,
-            defaultTimeoutMs: accessPolicyFlags.nativeWebFetchTimeoutMs,
-            maxResponseBytes: accessPolicyFlags.nativeWebFetchMaxBytes,
-            maxRedirects: accessPolicyFlags.nativeWebFetchMaxRedirects,
-            siteModeEnabled: accessPolicyFlags.nativeWebFetchSiteModeEnabled,
-            siteModeMaxPages: accessPolicyFlags.nativeWebFetchSiteModeMaxPages,
-            siteModeDepth: accessPolicyFlags.nativeWebFetchSiteModeDepth,
-        };
-
-        const web_fetch = tool({
-            description: "Fetch and extract readable content from a public web URL. Best for reading a specific link and using it as context.",
-            inputSchema: z.object({
-                url: z.string().describe("Public http/https URL to read"),
-                mode: z.enum(["markdown", "text"]).optional().describe("Output format. Defaults to markdown."),
-                maxChars: z.number().int().positive().max(100000).optional().describe("Maximum characters to return. Defaults to server policy."),
-                followRedirects: z.boolean().optional().describe("Whether to follow redirects. Defaults to true."),
-                timeoutMs: z.number().int().positive().max(60000).optional().describe("Request timeout in milliseconds. Defaults to server policy."),
-                siteMode: z.boolean().optional().describe("Optional whole-site mode. Disabled unless explicitly enabled by server configuration."),
-                siteModeSameDomain: z.boolean().optional().describe("When siteMode is enabled, limit crawl to the same domain. Defaults to true."),
-                siteModeMaxPages: z.number().int().positive().max(100).optional().describe("When siteMode is enabled, maximum pages to crawl (capped by server policy)."),
-                siteModeDepth: z.number().int().min(0).max(5).optional().describe("When siteMode is enabled, crawl depth (capped by server policy)."),
-            }),
-            execute: async ({ url, mode, maxChars, followRedirects, timeoutMs, siteMode, siteModeSameDomain, siteModeMaxPages, siteModeDepth }) => {
-                try {
-                    const result = await WebFetchService.fetchPage({
-                        url,
-                        mode,
-                        maxChars,
-                        followRedirects,
-                        timeoutMs,
-                        siteMode,
-                        siteModeSameDomain,
-                        siteModeMaxPages,
-                        siteModeDepth,
-                    }, webFetchPolicy);
-                    return JSON.stringify({ success: true, ...result }, null, 2);
-                } catch (error) {
-                    if (error instanceof WebFetchError) {
-                        return JSON.stringify({
-                            success: false,
-                            code: error.code,
-                            error: error.message,
-                        });
-                    }
-                    const message = error instanceof Error ? error.message : "Unknown web fetch error";
-                    return JSON.stringify({
-                        success: false,
-                        code: "WEB_FETCH_UNKNOWN_ERROR",
-                        error: message,
-                    });
-                }
-            },
-        });
-
-        // Merge native + MCP tools (OpenRouter server tools added after model resolution)
-        const baseTools = {
-            ...tools,
-            read_file,
-            ...(webFetchPolicy.enabled ? { web_fetch } : {}),
-        };
-
-        // Log web search status
-        if (webSearchConfig.enabled) {
-            console.log(`[Web Search] ENABLED (${webSearchConfig.useAgenticServerTools ? 'agentic server tools' : 'legacy :online plugin'}) with context size: ${webSearchConfig.contextSize}`);
-        } else {
-            console.log(`[Web Search] DISABLED`);
-        }
-
-        if (imageGenerationConfig.enabled) {
-            console.log(`[Image Generation] ENABLED (model: ${imageGenerationConfig.model}, quality: ${imageGenerationConfig.quality}, aspect: ${imageGenerationConfig.aspectRatio})`);
-        } else if (imageGeneration.enabled) {
-            console.log(`[Image Generation] Requested but not available for ${selectedModel}`);
-        } else {
-            console.log(`[Image Generation] DISABLED`);
-        }
-
-        let effectiveWebSearchEnabled = webSearchConfig.enabled;
-        let openRouterServerTools: Record<string, unknown> = {};
-
-        const openrouterUserId = authenticatedUser.isAnonymous
-            ? `chatlima_anon_${authenticatedUser.userId}`
-            : `chatlima_user_${authenticatedUser.userId}`;
-
-        // Add API key validation for OpenRouter models to prevent authentication errors
-        if (selectedModel.startsWith("openrouter/")) {
-            const openrouterApiKey = apiKeys?.['OPENROUTER_API_KEY'] || process.env.OPENROUTER_API_KEY;
-            if (!openrouterApiKey) {
-                console.error(`[Chat ${id}] OpenRouter API key is missing for model ${selectedModel}`);
-                return createErrorResponse(
-                    "MISSING_API_KEY",
-                    "OpenRouter API key is required for this model. Please configure your API key.",
-                    400
-                );
-            }
-
-            console.log(`[Chat ${id}] OpenRouter API key available: ${openrouterApiKey.substring(0, 8)}...`);
-        }
-
-        const webSearchSetup = resolveOpenRouterWebSearchRouteSetup({
-            selectedModel,
-            webSearchConfig,
-            modelInfo: selectedModelInfo,
-            apiKeys,
-            openrouterUserId,
-            getLanguageModelWithKeys,
-            createOpenRouterClientWithKey,
-            usesTagBasedReasoningExtraction,
-            wrapWithTagBasedReasoning,
-        });
-
-        const modelInstance = webSearchSetup.modelInstance;
-        effectiveWebSearchEnabled = webSearchSetup.effectiveWebSearchEnabled;
-        openRouterServerTools = webSearchSetup.openRouterServerTools;
-        const modelOptions = webSearchSetup.modelOptions;
-
-        if (webSearchConfig.enabled && webSearchConfig.useAgenticServerTools && Object.keys(openRouterServerTools).length > 0) {
-            console.log(`[Web Search] Agentic server tools enabled for ${selectedModel}`);
-        } else if (webSearchConfig.enabled && !webSearchConfig.useAgenticServerTools && effectiveWebSearchEnabled) {
-            const legacyModelId = ChatWebSearchService.getWebSearchModelId(selectedModel, webSearchConfig)
-                .replace("openrouter/", "");
-            console.log(`[Web Search] Legacy :online enabled for ${selectedModel} using ${legacyModelId}`);
-        } else if (webSearchConfig.enabled && !effectiveWebSearchEnabled) {
-            console.log(`[Web Search] Requested for ${selectedModel}, but not supported or unavailable. Using standard model.`);
-        } else if (webSearchConfig.enabled && !selectedModel.startsWith("openrouter/")) {
-            console.log(`[Web Search] Requested but ${selectedModel} is not an OpenRouter model. Disabling web search for this call.`);
-        }
-
-        const allTools = {
-            ...baseTools,
-            ...openRouterServerTools,
-            ...ChatImageGenerationService.buildOpenRouterServerTools(
-                imageGenerationConfig,
-                apiKeys?.OPENROUTER_API_KEY || process.env.OPENROUTER_API_KEY
-            ),
-        };
-
-        const lastUserMessageText = (() => {
-            for (let i = messages.length - 1; i >= 0; i--) {
-                const msg = messages[i];
-                if (msg.role === 'user') {
-                    return getUIMessageText(msg);
-                }
-            }
-            return '';
-        })();
-
-        const userRequestedImageCreation =
-            imageGenerationConfig.enabled &&
-            userMessageRequestsImageCreation(lastUserMessageText);
-
-        const shouldForceImageGenerationTool =
-            userRequestedImageCreation &&
-            ChatImageGenerationService.modelSupportsForcedToolChoice(selectedModel);
-
-        if (userRequestedImageCreation) {
-            if (shouldForceImageGenerationTool) {
-                console.log(
-                    `[Image Generation] Forcing image_generation tool on first step for ${selectedModel}`
-                );
-            } else {
-                console.log(
-                    `[Image Generation] Skipping forced tool_choice for ${selectedModel} (thinking mode); relying on system prompt`
-                );
-            }
-        }
-
-        // Always set logprobs: false for these models at the providerOptions level for streamText
-        if (
-            selectedModel === "openrouter/deepseek/deepseek-r1" ||
-            selectedModel === "openrouter/deepseek/deepseek-r1-0528" ||
-            selectedModel === "openrouter/x-ai/grok-3-beta" ||
-            selectedModel === "openrouter/x-ai/grok-3-mini-beta" ||
-            selectedModel === "openrouter/x-ai/grok-3-mini-beta-reasoning-high" ||
-            selectedModel === "openrouter/qwen/qwq-32b" ||
-            selectedModel.includes("openrouter/minimax/m2") ||
-            selectedModel.includes("openrouter/minimax-m2")
-        ) {
-            modelOptions.logprobs = false;
-        }
-
-        if (isGoogleModel(selectedModel)) {
-            console.log(`[GOOGLE MODEL DETECTED] ${selectedModel} - Will wrap tool input schemas without $schema metadata`);
-        }
-
-        const toolsToUse = isGoogleModel(selectedModel) && Object.keys(allTools).length > 0
-            ? cleanToolsForGoogleModels(allTools)
-            : allTools;
-
-        // Get default parameters and apply preset overrides
-        const modelDefaults = getModelDefaults(selectedModelInfo);
-        const effectiveTemperature = temperature !== undefined ? temperature : modelDefaults.temperature;
-        const effectiveMaxTokens = maxTokens !== undefined ? maxTokens : modelDefaults.maxTokens;
-        let effectiveSystemInstruction = systemInstruction !== undefined
-            ? sanitizeSystemInstruction(systemInstruction)
-            : `You are a helpful AI assistant. Today's date is ${new Date().toISOString().split('T')[0]}.
-
-You have access to external tools provided by connected servers. These tools can perform specific actions like running code, searching databases, or accessing external services.
-
-## File Attachments:
-When a user message contains an "[Attached files:]" section with "filepath" and/or "url":
-1. Use the \`read_file\` tool to inspect the relevant file(s) before answering questions about file contents.
-2. Prefer using the \`filepath\` value when provided; if unavailable, use the file URL.
-3. If reading a file fails, clearly explain what failed and what the user can retry.
-
-${webFetchPolicy.enabled ? `
-## Native URL Fetch:
-When users ask to read, summarize, analyze, or extract information from a URL:
-1. Prefer the \`web_fetch\` tool for direct page reading.
-2. For messages containing multiple URLs, fetch the first URL unless the user explicitly asks for all.
-3. Only use \`siteMode: true\` when the user explicitly asks for whole-site or multi-page crawling.
-4. Cite the source URL in your response and mention when content was truncated.
-5. If fetching fails, explain the failure and suggest retrying or narrowing scope.
-` : ''}
-
-${webSearchConfig.useAgenticServerTools ? `
-## Web Search Enabled (Agentic):
-You have the \`web_search\` server tool available. Use it when the user needs current information from the web.
-1. Only search when fresh information is required
-2. Cite sources using markdown links: [domain.com](full-url)
-3. Prefer OpenRouter fetch for pages discovered during search; use native \`web_fetch\` for explicit user-provided URLs
-` : effectiveWebSearchEnabled ? `
-## Web Search Enabled:
-You have web search capabilities enabled. When you use web search:
-1. Cite your sources using markdown links
-2. Use the format [domain.com](full-url) for citations
-3. Only cite reliable and relevant sources
-4. Integrate the information naturally into your responses
-` : ''}
-
-${imageGenerationConfig.enabled ? `
-## Image Generation Enabled:
-You have the \`image_generation\` server tool available. Use it when the user wants you to create, draw, or generate an image.
-1. Call the tool with a detailed visual prompt when image creation is requested or clearly implied
-2. After generation, describe what was created and reference the image naturally in your reply
-3. If generation fails due to content policy, explain clearly and suggest a revised prompt
-` : ''}
-
-## How to Respond:
-1.  **Analyze the Request:** Understand what the user is asking.
-2.  **Use Tools When Necessary:** If an external tool provides the best way to answer (e.g., fetching specific data, performing calculations, interacting with services), select the most relevant tool(s) and use them. You can use multiple tools in sequence. Clearly indicate when you are using a tool and what it's doing.
-3.  **Use Your Own Abilities:** For requests involving brainstorming, explanation, writing, summarization, analysis, or general knowledge, rely on your own reasoning and knowledge base. You don't need to force the use of an external tool if it's not suitable or required for these tasks.
-4.  **Respond Clearly:** Provide your answer directly when using your own abilities. If using tools, explain the steps taken and present the results clearly.
-5.  **Handle Limitations:** If you cannot answer fully (due to lack of information, missing tools, or capability limits), explain the limitation clearly. Don't just say "I don't know" if you can provide partial information or explain *why* you can't answer. If relevant tools seem to be missing, you can mention that the user could potentially add them via the server configuration.
-
-## Response Format:
-- Use Markdown for formatting.
-- Base your response on the results from any tools used, or on your own reasoning and knowledge.
-`;
-
-        let projectContext: Awaited<ReturnType<typeof buildProjectContext>> = null;
-        const projectFileUrlByPath = new Map<string, string>();
-
-        try {
-            projectContext = await buildProjectContext({
-                chatId: id,
-                userId: authenticatedUser.userId,
-            });
-
-            if (projectContext) {
-                for (const file of projectContext.files) {
-                    if (file.filepath && file.url) {
-                        projectFileUrlByPath.set(file.filepath, file.url);
-                    }
-                }
-                effectiveSystemInstruction = `${effectiveSystemInstruction}\n\n${formatProjectContextForSystemPrompt(projectContext)}`;
-            }
-        } catch (projectContextError) {
-            console.warn(`[Chat ${id}] Failed to build project context:`, projectContextError);
-        }
-
-        console.log('[DEBUG] Effective parameters:', {
-            temperature: effectiveTemperature,
-            maxTokens: effectiveMaxTokens,
-            systemInstructionLength: effectiveSystemInstruction.length
-        });
-
-        // Convert to appropriate format for OpenRouter and Requesty models
-        const isOpenRouterModel = selectedModel.startsWith("openrouter/");
-        const isRequestyModel = selectedModel.startsWith("requesty/");
-        const needsFormatConversion = isOpenRouterModel || isRequestyModel;
-
-        let formattedMessages = needsFormatConversion
-            ? convertToOpenRouterFormat(modelMessagesFinal)
-            : modelMessagesFinal;
-
-        // Filter out tool messages - they should not be sent to AI SDK as input
-        // Tool messages are only used in responses, not in conversation history
-        formattedMessages = formattedMessages.filter((msg: any) => msg.role !== "tool");
-
-        console.log(`[DEBUG] Using ${needsFormatConversion ? 'converted' : 'raw'} message format for model:`, selectedModel);
-        console.log("[DEBUG] Formatted messages for model:", JSON.stringify(formattedMessages, null, 2));
-
-        const streamFinishGate = createStreamFinishGate();
-        const streamFinishState = {
-            tokenUsageData: null as any,
-            messagesSavedSuccessfully: false,
-            savedAssistantPartCount: 0,
-            actualMessageId: undefined as string | undefined,
-            finalAssistantMessageId: nanoid(),
-            uiResponseMessage: null as UIMessage | null,
-            streamFinishEvent: null as any,
-            streamFinishResponse: null as OpenRouterResponse | null,
-        };
-
-        let persistInFlight: Promise<void> = Promise.resolve();
-
-        const persistAssistantMessages = async (
-            source: 'ui' | 'stream',
-            responseMessage?: UIMessage,
-        ) => {
-            const runPersist = async () => {
-            const uiMsg = responseMessage ?? streamFinishState.uiResponseMessage;
-            const event = streamFinishState.streamFinishEvent;
-            const response = streamFinishState.streamFinishResponse;
-
-            if (!uiMsg?.parts?.length && !event?.text) {
-                return;
-            }
-
-            try {
-                const clientMessages = messages as UIMessage[];
-                const trailingAssistant = clientMessages[clientMessages.length - 1];
-                const historyMessages =
-                    trailingAssistant?.role === 'assistant'
-                        ? clientMessages.slice(0, -1)
-                        : clientMessages;
-
-                const responseAssistantId = response?.messages
-                    ?.filter((m: { role?: string }) => m.role === 'assistant')
-                    .pop()?.id;
-
-                const assistantMessage = buildAssistantMessageForPersistence({
-                    clientMessages,
-                    uiResponseMessage: uiMsg ?? null,
-                    streamText: event?.text || '',
-                    reasoningText: event?.reasoningText,
-                    responseAssistantId,
-                });
-
-                if (streamFinishState.messagesSavedSuccessfully) {
-                    const newCount = countPersistableDisplayParts(assistantMessage.parts);
-                    if (newCount <= streamFinishState.savedAssistantPartCount) {
-                        return;
-                    }
-                }
-
-                const webSearchInvocationCount = event
-                    ? ChatWebSearchService.resolveWebSearchInvocationCount({
-                        steps: event.steps,
-                        usage: event.usage,
-                    })
-                    : 0;
-                const webSearchWasUsed = event
-                    ? ChatWebSearchService.messageUsedWebSearch({
-                        steps: event.steps,
-                        usage: event.usage,
-                        hasCitationAnnotations: (response?.annotations?.length || 0) > 0,
-                    })
-                    : false;
-
-                const imageUrlsFromStream = extractGeneratedImageUrlsFromStreamEvent(
-                    event,
-                    response
-                );
-                const imageGenerationWasUsed =
-                    imageGenerationConfig.enabled &&
-                    (ChatImageGenerationService.countImageGenerationInvocations(event?.steps) > 0 ||
-                        imageUrlsFromStream.length > 0);
-
-                const processedMessages = processMessagesForPersistence({
-                    historyMessages,
-                    assistantMessage,
-                    annotations: response?.annotations,
-                    webSearch: {
-                        useAgenticServerTools: webSearchConfig.useAgenticServerTools,
-                        enabled: effectiveWebSearchEnabled,
-                        wasUsed: webSearchWasUsed,
-                        invocationCount: webSearchInvocationCount,
-                    },
-                    imageGeneration: imageGenerationConfig.enabled
-                        ? {
-                              enabled: true,
-                              wasUsed: imageGenerationWasUsed,
-                              imageUrls: imageUrlsFromStream,
-                          }
-                        : undefined,
-                });
-
-                const processedAssistant = processedMessages.find((m) => m.role === 'assistant');
-                if (processedAssistant && source === 'ui') {
-                    streamFinishState.uiResponseMessage = processedAssistant;
-                }
-
-                const logTag = source === 'ui' ? 'uiOnFinish' : 'onFinish';
-                console.log(`[Chat ${id}][${logTag}] Persisting assistant parts:`, {
-                    partTypes:
-                        processedMessages
-                            .find((m) => m.role === 'assistant')
-                            ?.parts?.map((p) => p.type) ?? [],
-                    partCount:
-                        processedMessages.find((m) => m.role === 'assistant')?.parts?.length ?? 0,
-                });
-
-                const dbMessages = (convertToDBMessages(processedMessages as any, id) as any[]).map(msg => ({
-                    ...msg,
-                    hasWebSearch: effectiveWebSearchEnabled && msg.role === 'assistant' && (
-                        webSearchConfig.useAgenticServerTools
-                            ? webSearchWasUsed
-                            : (response?.annotations?.length || 0) > 0
-                    ),
-                    webSearchContextSize: webSearchConfig.enabled ? webSearchConfig.contextSize : undefined
-                }));
-
-                const savedAssistant = dbMessages.find(msg => msg.role === 'assistant');
-                streamFinishState.finalAssistantMessageId =
-                    savedAssistant?.id ||
-                    response?.messages?.filter((m: { role?: string }) => m.role === 'assistant').pop()?.id ||
-                    streamFinishState.finalAssistantMessageId;
-
-                await saveMessages({ messages: dbMessages });
-                streamFinishState.messagesSavedSuccessfully = true;
-                streamFinishState.savedAssistantPartCount = countPersistableDisplayParts(
-                    processedAssistant?.parts ?? assistantMessage.parts
-                );
-                console.log(`[Chat ${id}][${logTag}] Successfully saved messages.`);
-
-                await saveChat({
-                    id,
-                    userId: authenticatedUser.userId,
-                    messages: processedMessages as any,
-                    selectedModel,
-                    apiKeys,
-                    isAnonymous: authenticatedUser.isAnonymous,
-                    titleGenerationPromise,
-                });
-
-                try {
-                    const savedMessages = await db.query.messages.findMany({
-                        where: eq(messagesTable.chatId, id),
-                        orderBy: [messagesTable.createdAt]
-                    });
-                    const assistantRow = savedMessages.find(msg => msg.role === 'assistant');
-                    if (assistantRow) {
-                        streamFinishState.actualMessageId = assistantRow.id;
-                    }
-                } catch (msgQueryError) {
-                    console.warn(`[Chat ${id}][${logTag}] Could not query actual message ID:`, msgQueryError);
-                }
-            } catch (persistError: any) {
-                const logTag = source === 'ui' ? 'uiOnFinish' : 'onFinish';
-                console.error(`[Chat ${id}][${logTag}] Failed to persist messages:`, persistError);
-            }
-            };
-
-            persistInFlight = persistInFlight.then(runPersist, runPersist);
-            await persistInFlight;
-        };
-
-        const trackTokenUsageFromStreamFinish = async (event: any, response: OpenRouterResponse) => {
-            const typedResponse = response as any;
-            let completionTokens = 0;
-
-            if (typedResponse.usage?.completion_tokens) {
-                completionTokens = typedResponse.usage.completion_tokens;
-            } else if (typedResponse.usage?.output_tokens) {
-                completionTokens = typedResponse.usage.output_tokens;
-            } else {
-                const lastMessage = typedResponse.messages?.[typedResponse.messages.length - 1];
-                if (lastMessage?.content) {
-                    let contentLength = 0;
-                    if (Array.isArray(lastMessage.content)) {
-                        contentLength = lastMessage.content
-                            .filter((part: any) => part.type === 'text')
-                            .map((part: any) => part.text)
-                            .join('').length;
-                    } else if (typeof lastMessage.content === 'string') {
-                        contentLength = lastMessage.content.length;
-                    }
-                    completionTokens = Math.ceil(contentLength / 4);
-                } else if (typeof typedResponse.content === 'string') {
-                    completionTokens = Math.ceil(typedResponse.content.length / 4);
-                } else {
-                    completionTokens = 1;
-                }
-            }
-
-            if (completionTokens <= 0) {
-                return;
-            }
-
-            let polarCustomerId: string | undefined;
-            try {
-                const session = await auth.api.getSession({ headers: req.headers });
-                polarCustomerId = (session?.user as any)?.polarCustomerId ||
-                    (session?.user as any)?.metadata?.polarCustomerId;
-            } catch (error) {
-                console.warn('Failed to get session for Polar customer ID:', error);
-            }
-
-            let isAnonymous = authenticatedUser.isAnonymous;
-            try {
-                const session = await auth.api.getSession({ headers: req.headers });
-                isAnonymous = (session?.user as any)?.isAnonymous === true;
-            } catch {
-                // keep default
-            }
-
-            const callbackIsUsingOwnApiKeys = checkIfUsingOwnApiKeys(selectedModel, apiKeys);
-            let callbackActualCredits: number | null = null;
-            if (!isAnonymous && authenticatedUser.userId) {
-                try {
-                    callbackActualCredits = await getCachedCreditsByExternal(authenticatedUser.userId);
-                } catch (error) {
-                    logDiagnostic('LEGACY_TOKEN_TRACKING_WARNING', `Error getting actual credits in onFinish`, {
-                        requestId,
-                        userId: authenticatedUser.userId,
-                        error: error instanceof Error ? error.message : String(error),
-                    });
-                }
-            }
-
-            const isFreeModel = selectedModel.endsWith(':free');
-            let shouldDeductCredits = false;
-            if (!isAnonymous && !callbackIsUsingOwnApiKeys && !isFreeModel && callbackActualCredits !== null && callbackActualCredits > 0) {
-                shouldDeductCredits = true;
-            }
-
-            let additionalCost = 0;
-            if (shouldDeductCredits) {
-                additionalCost =
-                    ChatWebSearchService.computeWebSearchCreditCost({
-                        webSearchEnabled: webSearchConfig.enabled,
-                        useAgenticServerTools: webSearchConfig.useAgenticServerTools,
-                        isUsingOwnApiKeys: callbackIsUsingOwnApiKeys,
-                        shouldDeductCredits,
-                        steps: event.steps,
-                        usage: event.usage,
-                        hasCitationAnnotations: (response.annotations?.length || 0) > 0,
-                    }) +
-                    ChatImageGenerationService.computeImageGenerationCreditCost({
-                        imageGenerationEnabled: imageGenerationConfig.enabled,
-                        isUsingOwnApiKeys: callbackIsUsingOwnApiKeys,
-                        shouldDeductCredits,
-                        model: imageGenerationConfig.model,
-                        steps: event.steps,
-                    });
-            }
-
-            const tokenUsageData = streamFinishState.tokenUsageData;
-            const extractedInputTokens = extractInputTokensFromEvent(event);
-            const finalInputTokens = tokenUsageData?.inputTokens || extractedInputTokens;
-            const finalOutputTokens = tokenUsageData?.outputTokens || completionTokens;
-            const openrouterApiKey = apiKeys?.['OPENROUTER_API_KEY'] || process.env.OPENROUTER_API_KEY;
-
-            import('@/lib/services/costReconciliation').then(async ({ CostReconciliationService }) => {
-                try {
-                    await CostReconciliationService.reconcileRecentMissingActualCosts({
-                        limit: 3,
-                        maxAgeHours: 48,
-                        apiKeyOverride: openrouterApiKey,
-                    });
-                } catch {
-                    // Swallow errors silently
-                }
-            });
-
-            await DirectTokenTrackingService.processTokenUsage({
-                userId: authenticatedUser.userId,
-                chatId: id,
-                // Chat messages are replaced during post-stream persistence upgrades
-                // (text-only -> full UI parts). Keep usage scoped to the chat so
-                // those message deletes do not cascade-delete token metrics.
-                messageId: undefined,
-                modelId: selectedModel,
-                provider: selectedModel.split('/')[0],
-                inputTokens: finalInputTokens,
-                outputTokens: finalOutputTokens,
-                generationId: typedResponse.id || typedResponse.generation_id || typedResponse.generationId || undefined,
-                openRouterResponse: typedResponse,
-                providerResponse: typedResponse,
-                apiKeyOverride: openrouterApiKey,
-                processingTimeMs: Date.now() - requestStartTime,
-                timeToFirstTokenMs: timeToFirstTokenMs ?? undefined,
-                tokensPerSecond: tokensPerSecond ?? undefined,
-                streamingStartTime: streamingStartTime ?? undefined,
-                polarCustomerId,
-                completionTokens,
-                isAnonymous,
-                shouldDeductCredits,
-                additionalCost,
-                modelInfo: modelValidation.modelInfo ?? undefined,
-            });
-        };
-
-        const handleUiStreamFinish = async (responseMessage: UIMessage) => {
-            streamFinishState.uiResponseMessage = responseMessage;
-            await persistAssistantMessages('ui', responseMessage);
-        };
-
-        const handleStreamTextFinishReady = (event: any, response: OpenRouterResponse) => {
-            streamFinishState.streamFinishEvent = event;
-            streamFinishState.streamFinishResponse = response;
-            streamFinishGate.notify(event, response);
-        };
-
-        const finalizeStreamPersistence = async () => {
-            if (!streamFinishState.streamFinishEvent || !streamFinishState.streamFinishResponse) {
-                return;
-            }
-
-            // UI onFinish usually follows with MCP tool-* parts; brief wait avoids text-only saves
-            for (let i = 0; i < 30 && !streamFinishState.uiResponseMessage; i++) {
-                await new Promise((resolve) => setTimeout(resolve, 200));
-            }
-
-            if (streamFinishState.messagesSavedSuccessfully) {
-                if (streamFinishState.uiResponseMessage) {
-                    await persistAssistantMessages('stream', streamFinishState.uiResponseMessage);
-                }
-                return;
-            }
-
-            await persistAssistantMessages('stream', streamFinishState.uiResponseMessage ?? undefined);
-        };
-
-        // 17. Set up streaming payload
-        const openRouterPayload = {
-            model: modelInstance as LanguageModel,
-            abortSignal: streamAbortController.signal,
-            system: effectiveSystemInstruction,
-            temperature: effectiveTemperature,
-            maxOutputTokens: effectiveMaxTokens,
-            messages: formattedMessages,
-            tools: toolsToUse,
-            ...(shouldForceImageGenerationTool
-                ? {
-                      prepareStep: async ({ stepNumber }: { stepNumber: number }) => {
-                          if (stepNumber === 0) {
-                              return {
-                                  toolChoice: {
-                                      type: 'tool' as const,
-                                      toolName: 'image_generation' as any,
-                                  },
-                              };
-                          }
-                          return {};
-                      },
-                  }
-                : {}),
-            stopWhen: stepCountIs(20),
-            user: authenticatedUser.isAnonymous
-                ? `chatlima_anon_${authenticatedUser.userId}`
-                : `chatlima_user_${authenticatedUser.userId}`,
-            providerOptions: {
-                google: {
-                    thinkingConfig: {
-                        thinkingBudget: 2048,
-                    },
-                },
-                anthropic: {
-                    thinking: {
-                        type: 'enabled',
-                        budgetTokens: 12000
-                    },
-                },
-                openrouter: {
-                    ...modelOptions,
-                    user: authenticatedUser.isAnonymous
-                        ? `chatlima_anon_${authenticatedUser.userId}`
-                        : `chatlima_user_${authenticatedUser.userId}`,
-                    extraBody: {
-                        user: authenticatedUser.isAnonymous
-                            ? `chatlima_anon_${authenticatedUser.userId}`
-                            : `chatlima_user_${authenticatedUser.userId}`,
-                    },
-                },
-            },
-            onError: (error: any) => {
-                console.error(`[streamText.onError][Chat ${id}] Error during LLM stream:`, JSON.stringify(error, null, 2));
-            },
-            onChunk: (chunk: any) => {
-                // Track time to first token
-                if (firstTokenTime === null) {
-                    firstTokenTime = Date.now();
-                    timeToFirstTokenMs = firstTokenTime - requestStartTime;
-
-                    if (streamingStartTime === null) {
-                        streamingStartTime = new Date();
-                    }
-
-                    logDiagnostic('FIRST_TOKEN', `First token received`, {
-                        requestId,
-                        firstTokenTime,
-                        timeToFirstTokenMs,
-                        chunkType: chunk.type
-                    });
-                }
-
-                logChunk(id, chunk, firstTokenTime, requestId);
-            },
-            async onFinish(event: any) {
-                console.log(`[Chat ${id}][onFinish] Stream finished, computing usage...`);
-
-                let tokenUsageData: any = null;
-
-                const provider = selectedModel.split('/')[0];
-                console.log(`[Chat ${id}][onFinish] Event data for provider ${provider}:`, {
-                    eventKeys: Object.keys(event),
-                    hasResponse: !!event.response,
-                    hasUsage: !!event.usage,
-                    hasDuration: !!event.durationMs,
-                    hasTimestamp: !!event.timestamp,
-                    firstTokenTime,
-                    timeToFirstTokenMs,
-                    streamingStartTime,
-                    requestStartTime,
-                    provider: provider,
-                    eventUsage: event.usage,
-                    responseUsage: event.response?.usage,
-                    eventUsageKeys: event.usage ? Object.keys(event.usage) : [],
-                    responseUsageKeys: event.response?.usage ? Object.keys(event.response.usage) : [],
-                    eventUsageDetailedDebug: event.usage ? {
-                        promptTokens: { value: event.usage.promptTokens, type: typeof event.usage.promptTokens, isNaN: isNaN(event.usage.promptTokens) },
-                        completionTokens: { value: event.usage.completionTokens, type: typeof event.usage.completionTokens, isNaN: isNaN(event.usage.completionTokens) },
-                        totalTokens: { value: event.usage.totalTokens, type: typeof event.usage.totalTokens, isNaN: isNaN(event.usage.totalTokens) }
-                    } : null,
-                    stepsDebug: event.steps ? {
-                        stepsCount: event.steps.length,
-                        stepsKeys: event.steps.map((step: any, i: number) => ({ index: i, keys: Object.keys(step) })),
-                        stepsUsage: event.steps.map((step: any, i: number) => ({
-                            index: i,
-                            hasUsage: !!step.usage,
-                            usage: step.usage
-                        }))
-                    } : null
-                });
-
-                if (timeToFirstTokenMs === null) {
-                    timeToFirstTokenMs = 500;
-                    console.log(`[Chat ${id}][onFinish] Forced timeToFirstTokenMs to 500ms for testing`);
-                }
-
-                const response = event.response as OpenRouterResponse;
-
-                try {
-                    if (!response || !response.messages) {
-                        console.error(`[Chat ${id}][onFinish] Invalid response structure:`, response);
-                        return;
-                    }
-
-                    console.log(`[Chat ${id}][onFinish] Response has annotations:`, !!response.annotations);
-                    if (response.annotations) {
-                        console.log(`[Chat ${id}][onFinish] Annotation count:`, response.annotations.length);
-                        console.log(`[Chat ${id}][onFinish] Annotation types:`, response.annotations.map(a => a.type));
-                    }
-
-                    handleStreamTextFinishReady(event, response);
-                    streamFinishState.finalAssistantMessageId =
-                        response.messages?.filter((m: { role?: string }) => m.role === 'assistant').pop()?.id ||
-                        streamFinishState.finalAssistantMessageId;
-
-                    const typedResponse = response as any;
-                    const provider = selectedModel.split('/')[0];
-
-                    try {
-                        logDiagnostic('TOKEN_TRACKING_START', `Starting detailed token tracking`, {
-                            requestId,
-                            userId: authenticatedUser.userId,
-                            chatId: id,
-                            messageId: streamFinishState.finalAssistantMessageId,
-                            modelId: selectedModel,
-                            provider,
-                            tokenUsage: typedResponse.usage || {
-                                inputTokens: 0,
-                                outputTokens: 0,
-                                totalTokens: 0
-                            }
-                        });
-
-                        const lastMessage = typedResponse.messages?.[typedResponse.messages.length - 1];
-                        const lastMessageContent = lastMessage?.content;
-                        let contentPreview = '';
-
-                        if (typeof lastMessageContent === 'string') {
-                            contentPreview = lastMessageContent.substring(0, 100);
-                        } else if (Array.isArray(lastMessageContent)) {
-                            const textParts = lastMessageContent
-                                .filter((part: any) => part.type === 'text')
-                                .map((part: any) => part.text)
-                                .join(' ');
-                            contentPreview = textParts.substring(0, 100);
-                        } else if (lastMessageContent) {
-                            contentPreview = JSON.stringify(lastMessageContent).substring(0, 100);
-                        }
-
-                        const generationId = provider === 'openrouter' ?
-                            (typedResponse.id || typedResponse.generation_id || typedResponse.generationId) : null;
-
-                        console.log(`[Chat ${id}][onFinish] ${provider.toUpperCase()} response structure:`, {
-                            hasUsage: !!typedResponse.usage,
-                            usageKeys: typedResponse.usage ? Object.keys(typedResponse.usage) : [],
-                            usageValue: typedResponse.usage,
-                            hasMessages: !!typedResponse.messages,
-                            messageCount: typedResponse.messages?.length || 0,
-                            lastMessageContent: contentPreview,
-                            generationId: generationId,
-                            hasGenerationId: !!generationId,
-                            provider: provider
-                        });
-
-                        tokenUsageData = event.usage || typedResponse.usage;
-
-                        // Check for tool call steps and aggregate their token usage
-                        if (event.steps && Array.isArray(event.steps)) {
-                            console.log(`[Chat ${id}][onFinish] Found ${event.steps.length} steps, checking for tool call tokens`);
-
-                            let totalStepInputTokens = 0;
-                            let totalStepOutputTokens = 0;
-                            let hasStepTokens = false;
-
-                            for (let i = 0; i < event.steps.length; i++) {
-                                const step = event.steps[i];
-                                if (step && step.usage) {
-                                    const stepUsage = step.usage as any;
-                                    const stepInputTokens = stepUsage.promptTokens || stepUsage.inputTokens || stepUsage.prompt_tokens || stepUsage.input_tokens || 0;
-                                    const stepOutputTokens = stepUsage.completionTokens || stepUsage.outputTokens || stepUsage.completion_tokens || stepUsage.output_tokens || 0;
-
-                                    if (stepInputTokens > 0 || stepOutputTokens > 0) {
-                                        totalStepInputTokens += stepInputTokens;
-                                        totalStepOutputTokens += stepOutputTokens;
-                                        hasStepTokens = true;
-                                        console.log(`[Chat ${id}][onFinish] Step ${i} tokens: input=${stepInputTokens}, output=${stepOutputTokens}`);
-                                    }
-                                }
-                            }
-
-                            if (hasStepTokens) {
-                                console.log(`[Chat ${id}][onFinish] Aggregated step tokens: input=${totalStepInputTokens}, output=${totalStepOutputTokens}`);
-
-                                // Merge step tokens with main usage data
-                                tokenUsageData = {
-                                    ...tokenUsageData,
-                                    inputTokens: totalStepInputTokens || tokenUsageData?.inputTokens || tokenUsageData?.prompt_tokens || 0,
-                                    outputTokens: totalStepOutputTokens || tokenUsageData?.outputTokens || tokenUsageData?.completion_tokens || 0,
-                                    totalTokens: (totalStepInputTokens + totalStepOutputTokens) || tokenUsageData?.totalTokens || tokenUsageData?.total_tokens
-                                };
-                            }
-                        }
-
-                        console.log(`[Chat ${id}][onFinish] Raw ${provider.toUpperCase()} usage data:`, {
-                            hasEventUsage: !!event.usage,
-                            hasResponseUsage: !!typedResponse.usage,
-                            eventUsageKeys: event.usage ? Object.keys(event.usage) : [],
-                            responseUsageKeys: typedResponse.usage ? Object.keys(typedResponse.usage) : [],
-                            finalUsageSource: event.usage ? 'event.usage' : (typedResponse.usage ? 'response.usage' : 'none'),
-                            usageValue: tokenUsageData,
-                            inputTokens: tokenUsageData?.inputTokens,
-                            outputTokens: tokenUsageData?.outputTokens,
-                            promptTokens: tokenUsageData?.promptTokens,
-                            prompt_tokens: tokenUsageData?.prompt_tokens,
-                            completionTokens: tokenUsageData?.completionTokens,
-                            completion_tokens: tokenUsageData?.completion_tokens,
-                            total_tokens: tokenUsageData?.total_tokens,
-                            usageObject: tokenUsageData
-                        });
-
-                        const inputTokenCount = tokenUsageData?.inputTokens || tokenUsageData?.prompt_tokens || 0;
-                        const outputTokenCount = tokenUsageData?.outputTokens || tokenUsageData?.completion_tokens || 0;
-
-                        console.log(`[Chat ${id}][onFinish] Parsed token counts:`, {
-                            inputTokenCount,
-                            outputTokenCount,
-                            needsInputEstimation: inputTokenCount === 0,
-                            needsOutputEstimation: outputTokenCount === 0
-                        });
-
-                        const needsInputEstimation = !tokenUsageData ||
-                            inputTokenCount === 0 ||
-                            inputTokenCount === undefined;
-
-                        const needsOutputEstimation = !tokenUsageData ||
-                            outputTokenCount === 0 ||
-                            outputTokenCount === undefined;
-
-                        if (needsInputEstimation || needsOutputEstimation) {
-                            const lastMessage = typedResponse.messages?.[typedResponse.messages.length - 1];
-
-                            let outputContentLength = 0;
-                            let inputContentLength = 0;
-
-                            if (needsOutputEstimation && lastMessage?.content) {
-                                if (Array.isArray(lastMessage.content)) {
-                                    outputContentLength = lastMessage.content
-                                        .filter((part: any) => part.type === 'text')
-                                        .map((part: any) => part.text)
-                                        .join('').length;
-                                } else if (typeof lastMessage.content === 'string') {
-                                    outputContentLength = lastMessage.content.length;
-                                }
-                            }
-
-                            if (needsInputEstimation && modelMessagesFinal) {
-                                console.log(`[Chat ${id}][onFinish] Estimating input tokens from full conversation context (${modelMessagesFinal.length} messages)`);
-
-                                let totalInputContentLength = 0;
-
-                                modelMessagesFinal.forEach((message, index) => {
-                                    const messageContentLength = getUIMessageText(message).length;
-
-                                    totalInputContentLength += messageContentLength;
-
-                                    console.log(`[Chat ${id}][onFinish] Message ${index + 1} (${message.role}): ${messageContentLength} chars`);
-                                });
-
-                                inputContentLength = totalInputContentLength;
-                                console.log(`[Chat ${id}][onFinish] Total input content length: ${inputContentLength} chars (${modelMessagesFinal.length} messages)`);
-                            }
-
-                            if (needsInputEstimation && effectiveSystemInstruction) {
-                                const systemLength = effectiveSystemInstruction.length;
-                                inputContentLength += systemLength;
-                                console.log(`[Chat ${id}][onFinish] Added system instruction: ${systemLength} chars`);
-                            }
-
-                            const estimatedOutputTokens = Math.ceil(outputContentLength / 4);
-                            const estimatedInputTokens = Math.ceil(inputContentLength / 4);
-
-                            const finalInputTokens = needsInputEstimation ? estimatedInputTokens : inputTokenCount;
-                            const finalOutputTokens = needsOutputEstimation ? estimatedOutputTokens : outputTokenCount;
-
-                            tokenUsageData = {
-                                inputTokens: finalInputTokens,
-                                outputTokens: finalOutputTokens,
-                                totalTokens: finalInputTokens + finalOutputTokens
-                            };
-
-                            console.log(`[Chat ${id}][onFinish] Final token usage (estimated + OpenRouter):`, {
-                                originalInput: typedResponse.usage?.inputTokens,
-                                originalOutput: typedResponse.usage?.outputTokens,
-                                estimatedInput: estimatedInputTokens,
-                                estimatedOutput: estimatedOutputTokens,
-                                finalInput: finalInputTokens,
-                                finalOutput: finalOutputTokens,
-                                finalTotal: finalInputTokens + finalOutputTokens,
-                                conversationLength: modelMessagesFinal ? modelMessagesFinal.length : 0,
-                                totalInputChars: inputContentLength,
-                                systemInstructionChars: effectiveSystemInstruction ? effectiveSystemInstruction.length : 0
-                            });
-                        }
-
-                        const requestEndTime = Date.now();
-                        const calculatedProcessingTimeMs = requestEndTime - requestStartTime;
-
-                        const finalOutputTokens = tokenUsageData?.outputTokens || 0;
-
-                        if (timeToFirstTokenMs === null) {
-                            if (event?.durationMs) {
-                                timeToFirstTokenMs = Math.round(event.durationMs * 0.2);
-                                logDiagnostic('ESTIMATED_TIMING', `Estimated time to first token from event.durationMs`, {
-                                    requestId,
-                                    estimatedTimeToFirstTokenMs: timeToFirstTokenMs,
-                                    totalDurationMs: event.durationMs
-                                });
-                            } else {
-                                timeToFirstTokenMs = Math.round(calculatedProcessingTimeMs * 0.2);
-                                logDiagnostic('ESTIMATED_TIMING', `Estimated time to first token from calculated processing time`, {
-                                    requestId,
-                                    estimatedTimeToFirstTokenMs: timeToFirstTokenMs,
-                                    calculatedProcessingTimeMs
-                                });
-                            }
-                        }
-
-                        if (timeToFirstTokenMs !== null && finalOutputTokens > 0 && calculatedProcessingTimeMs > 0) {
-                            const generationTimeMs = calculatedProcessingTimeMs - timeToFirstTokenMs;
-                            if (generationTimeMs > 0) {
-                                tokensPerSecond = (finalOutputTokens / (generationTimeMs / 1000));
-                            }
-                        }
-
-                        logDiagnostic('ENHANCED_TIMING', `Enhanced timing metrics calculated`, {
-                            requestId,
-                            timeToFirstTokenMs,
-                            tokensPerSecond,
-                            streamingStartTime: streamingStartTime?.toISOString(),
-                            finalOutputTokens,
-                            calculatedProcessingTimeMs
-                        });
-
-                        console.log(`[DEBUG][Chat ${id}] About to call TokenTrackingService with timing data:`, {
-                            timeToFirstTokenMs,
-                            tokensPerSecond,
-                            streamingStartTime,
-                            calculatedProcessingTimeMs
-                        });
-
-                        streamFinishState.tokenUsageData = tokenUsageData;
-
-                        // Do not await persistence or billing here — streamText onFinish blocks
-                        // stream closure, and useChat stays in "streaming" until the HTTP body closes.
-                        void (async () => {
-                            try {
-                                await finalizeStreamPersistence();
-                            } catch (persistError) {
-                                console.error(`[Chat ${id}][onFinish] Failed stream persistence:`, persistError);
-                            }
-
-                            try {
-                                await trackTokenUsageFromStreamFinish(event, response);
-                            } catch (tokenError) {
-                                console.error(`[Chat ${id}][onFinish] Failed token tracking:`, tokenError);
-                            }
-                        })();
-
-                    } catch (error: any) {
-                        logDiagnostic('TOKEN_TRACKING_ERROR', `Failed to track detailed token usage (independent)`, {
-                            requestId,
-                            userId: authenticatedUser.userId,
-                            error: error instanceof Error ? error.message : String(error)
-                        });
-                        console.error(`[Chat ${id}][onFinish] Failed to track detailed token usage for user ${authenticatedUser.userId}:`, error);
-                    }
-                } catch (finishError: any) {
-                    console.error(`[Chat ${id}][onFinish] Unexpected error in onFinish:`, finishError);
-                }
-            }
-        };
-
-        console.log(`[Chat ${id}] Using model: ${selectedModel}, effectiveWebSearchEnabled: ${webSearchConfig.enabled}`);
-        console.log(`[Chat ${id}] OpenRouter user tracking: ${authenticatedUser.isAnonymous ? `chatlima_anon_${authenticatedUser.userId}` : `chatlima_user_${authenticatedUser.userId}`}`);
-
-        const result = streamText(openRouterPayload);
-        startBackgroundStreamConsumption(result, id);
-
-        return result.toUIMessageStreamResponse({
-            originalMessages: messages,
-            sendReasoning: true,
-            onFinish: ({ responseMessage }) => {
-                void handleUiStreamFinish(responseMessage).catch((err) => {
-                    console.error(`[Chat ${id}][uiOnFinish] Unhandled error:`, err);
-                });
-            },
-            onError: (error: unknown) => {
-                const err = error as any;
-                console.error(`[API Error][Chat ${id}] Error in stream processing:`, {
-                    error: err,
-                    message: err?.message,
-                    stack: err?.stack,
-                    responseBody: err?.responseBody,
-                    name: err?.name,
-                    cause: err?.cause,
-                });
-
-                if (err?.name === 'AI_TypeValidationError') {
-                    let errorMessage = "The AI provider returned an unexpected response format. Please try again.";
-                    if (err?.value?.error?.message) {
-                        errorMessage = `API Error: ${err.value.error.message}`;
-                    }
-                    return JSON.stringify({ error: { code: "PROVIDER_ERROR", message: errorMessage, details: "Type validation error" } });
-                }
-
-                let errorCode = "STREAM_ERROR";
-                let errorMessage = "An error occurred while processing your request.";
-                const errorDetails: any = {};
-
-                // Try to extract error details from various sources
-                if (err?.message) {
-                    errorDetails.rawMessage = err.message;
-                }
-
-                if (err?.cause) {
-                    errorDetails.cause = err.cause;
-                }
-
-                if (err && typeof err.responseBody === 'string') {
-                    try {
-                        const parsedBody = JSON.parse(err.responseBody);
-                        errorDetails.responseBody = parsedBody;
-                        if (parsedBody.error && typeof parsedBody.error.message === 'string') {
-                            errorMessage = parsedBody.error.message;
-                            if (parsedBody.error.code) {
-                                errorCode = String(parsedBody.error.code);
-                            }
-                        }
-                    } catch (e) {
-                        console.warn(`[API Error][Chat ${id}] Failed to parse error.responseBody`);
-                        errorDetails.responseBody = err.responseBody;
-                    }
-                }
-
-                // Check if error has standard properties
-                if (err?.code) {
-                    errorCode = String(err.code);
-                }
-
-                // Use error message if available
-                if (err?.message && !errorDetails.responseBody) {
-                    errorMessage = err.message;
-                }
-
-                // Log the final error for debugging
-                console.error(`[API Error][Chat ${id}] Final error response:`, { errorCode, errorMessage, errorDetails });
-
-                return JSON.stringify({ error: { code: errorCode, message: errorMessage, details: errorDetails } });
-            },
-        });
-
-    } catch (error: any) {
-        console.error(`[API Route Error][Chat ${requestId}] Error in refactored route:`, JSON.stringify(error, null, 2));
-
-        if (error instanceof Response) {
-            return error; // Already a proper error response
-        }
-
-        if (error instanceof ChatAuthenticationError) {
-            return createErrorResponse(error.code, error.message, error.status);
-        }
-
-        // Handle domain-specific credit validation errors
-        if (error instanceof CreditValidationError) {
-            return new Response(
-                JSON.stringify({
-                    error: {
-                        code: error.code,
-                        message: error.message,
-                        details: error.details
-                    }
-                }),
-                { status: error.status, headers: { "Content-Type": "application/json" } }
-            );
-        }
-
-        return new Response(
-            JSON.stringify({
-                error: {
-                    code: "INTERNAL_ERROR",
-                    message: "An internal error occurred",
-                    details: error.message
-                }
-            }),
-            { status: 500, headers: { "Content-Type": "application/json" } }
-        );
+    const preflightResult = await runChatPreflight(req, chatBody);
+    if (!preflightResult.ok) {
+      return preflightResult.response;
     }
+    const preflight = preflightResult.context;
+
+    const mcpResult = await ChatMCPServerService.initializeMCPServers({
+      mcpServers: chatBody.mcpServers,
+      selectedModel: chatBody.selectedModel,
+    });
+
+    if (mcpResult.cleanup) {
+      req.signal.addEventListener('abort', async () => {
+        await mcpResult.cleanup?.();
+      });
+    }
+
+    const chatId = chatBody.chatId || nanoid();
+    const streamAbortController = new AbortController();
+    registerChatAbortController(
+      preflight.authenticatedUser.userId,
+      chatId,
+      streamAbortController
+    );
+
+    const isNewChat =
+      !chatBody.chatId ||
+      !(await ChatDatabaseService.checkChatExists({
+        chatId,
+        userId: preflight.authenticatedUser.userId,
+      }));
+
+    if (isNewChat) {
+      await ChatDatabaseService.createChatIfNotExists({
+        id: chatId,
+        userId: preflight.authenticatedUser.userId,
+        selectedModel: chatBody.selectedModel,
+        apiKeys: chatBody.apiKeys,
+        isAnonymous: preflight.authenticatedUser.isAnonymous,
+        messages: [],
+      });
+    }
+
+    const titleGenerationPromise =
+      isNewChat && chatBody.messages.some((m) => m.role === 'user')
+        ? generateTitle(
+            chatBody.messages,
+            chatBody.selectedModel,
+            chatBody.apiKeys,
+            preflight.authenticatedUser.userId,
+            preflight.authenticatedUser.isAnonymous
+          ).then((title) => title ?? 'New Chat')
+        : undefined;
+
+    const planResult = await buildChatStreamPlan({
+      body: chatBody,
+      preflight,
+      chatId,
+      mcpResult,
+    });
+    if (!planResult.ok) {
+      return planResult.response;
+    }
+    const plan = planResult.plan;
+
+    const finalizer = createChatStreamFinalizer({
+      chatId,
+      requestId,
+      requestStartTime,
+      clientMessages: chatBody.messages,
+      authenticatedUser: preflight.authenticatedUser,
+      selectedModel: chatBody.selectedModel,
+      apiKeys: chatBody.apiKeys,
+      isAnonymous: preflight.authenticatedUser.isAnonymous,
+      plan,
+      modelValidation: preflight.modelValidation,
+      titleGenerationPromise,
+      getRemainingCreditsByExternalId: getCachedCreditsByExternal,
+    });
+
+    const { authenticatedUser } = preflight;
+    const openrouterUser = plan.openrouterUserId;
+
+    const streamPayload = {
+      model: plan.modelInstance as LanguageModel,
+      abortSignal: streamAbortController.signal,
+      system: plan.effectiveSystemInstruction,
+      temperature: plan.effectiveTemperature,
+      maxOutputTokens: plan.effectiveMaxTokens,
+      messages: plan.formattedMessages,
+      tools: plan.toolsToUse as ToolSet,
+      ...(plan.shouldForceImageGenerationTool
+        ? {
+            prepareStep: async ({ stepNumber }: { stepNumber: number }) => {
+              if (stepNumber === 0) {
+                return {
+                  toolChoice: {
+                    type: 'tool' as const,
+                    toolName: 'image_generation' as const,
+                  },
+                };
+              }
+              return {};
+            },
+          }
+        : {}),
+      stopWhen: stepCountIs(20),
+      user: openrouterUser,
+      providerOptions: {
+        google: {
+          thinkingConfig: {
+            thinkingBudget: 2048,
+          },
+        },
+        anthropic: {
+          thinking: {
+            type: 'enabled' as const,
+            budgetTokens: 12000,
+          },
+        },
+        openrouter: {
+          ...plan.modelOptions,
+          user: openrouterUser,
+          extraBody: {
+            user: openrouterUser,
+          },
+        },
+      },
+      onError: (error: unknown) => {
+        console.error(
+          `[streamText.onError][Chat ${chatId}] Error during LLM stream:`,
+          JSON.stringify(error, null, 2)
+        );
+      },
+      onChunk: (event: { chunk?: { type?: string } }) => {
+        finalizer.recordFirstToken();
+        const { timeToFirstTokenMs } = finalizer.getTimingMetrics();
+        const firstTokenTime =
+          timeToFirstTokenMs !== null ? requestStartTime + timeToFirstTokenMs : null;
+        logChunk(chatId, event.chunk ?? event, firstTokenTime, requestId);
+      },
+      async onFinish(event: Record<string, unknown>) {
+        const response = event.response as OpenRouterStreamResponse | undefined;
+        if (!response) {
+          return;
+        }
+        await finalizer.processStreamFinish(event, response);
+      },
+    };
+
+    console.log(
+      `[Chat ${chatId}] Using model: ${chatBody.selectedModel}, effectiveWebSearchEnabled: ${plan.webSearchConfig.enabled}`
+    );
+    console.log(`[Chat ${chatId}] OpenRouter user tracking: ${openrouterUser}`);
+
+    const result = streamText(streamPayload);
+    startBackgroundStreamConsumption(result, chatId);
+
+    return result.toUIMessageStreamResponse({
+      originalMessages: chatBody.messages,
+      sendReasoning: true,
+      onFinish: ({ responseMessage }) => {
+        void finalizer.handleUiStreamFinish(responseMessage).catch((err) => {
+          console.error(`[Chat ${chatId}][uiOnFinish] Unhandled error:`, err);
+        });
+      },
+      onError: (error: unknown) => {
+        const err = error as {
+          name?: string;
+          message?: string;
+          stack?: string;
+          responseBody?: string;
+          code?: string | number;
+          cause?: unknown;
+          value?: { error?: { message?: string } };
+        };
+
+        console.error(`[API Error][Chat ${chatId}] Error in stream processing:`, {
+          error: err,
+          message: err?.message,
+          stack: err?.stack,
+          responseBody: err?.responseBody,
+          name: err?.name,
+          cause: err?.cause,
+        });
+
+        if (err?.name === 'AI_TypeValidationError') {
+          let errorMessage =
+            'The AI provider returned an unexpected response format. Please try again.';
+          if (err?.value?.error?.message) {
+            errorMessage = `API Error: ${err.value.error.message}`;
+          }
+          return JSON.stringify({
+            error: {
+              code: 'PROVIDER_ERROR',
+              message: errorMessage,
+              details: 'Type validation error',
+            },
+          });
+        }
+
+        let errorCode = 'STREAM_ERROR';
+        let errorMessage = 'An error occurred while processing your request.';
+        const errorDetails: Record<string, unknown> = {};
+
+        if (err?.message) {
+          errorDetails.rawMessage = err.message;
+        }
+        if (err?.cause) {
+          errorDetails.cause = err.cause;
+        }
+
+        if (err && typeof err.responseBody === 'string') {
+          try {
+            const parsedBody = JSON.parse(err.responseBody);
+            errorDetails.responseBody = parsedBody;
+            if (parsedBody.error && typeof parsedBody.error.message === 'string') {
+              errorMessage = parsedBody.error.message;
+              if (parsedBody.error.code) {
+                errorCode = String(parsedBody.error.code);
+              }
+            }
+          } catch {
+            console.warn(`[API Error][Chat ${chatId}] Failed to parse error.responseBody`);
+            errorDetails.responseBody = err.responseBody;
+          }
+        }
+
+        if (err?.code) {
+          errorCode = String(err.code);
+        }
+        if (err?.message && !errorDetails.responseBody) {
+          errorMessage = err.message;
+        }
+
+        console.error(`[API Error][Chat ${chatId}] Final error response:`, {
+          errorCode,
+          errorMessage,
+          errorDetails,
+        });
+
+        return JSON.stringify({
+          error: { code: errorCode, message: errorMessage, details: errorDetails },
+        });
+      },
+    });
+  } catch (error: unknown) {
+    console.error(
+      `[API Route Error][Chat ${requestId}] Error in chat route:`,
+      JSON.stringify(error, null, 2)
+    );
+
+    if (error instanceof Response) {
+      return error;
+    }
+
+    if (error instanceof ChatAuthenticationError) {
+      return createErrorResponse(error.code, error.message, error.status);
+    }
+
+    if (error instanceof CreditValidationError) {
+      return new Response(
+        JSON.stringify({
+          error: {
+            code: error.code,
+            message: error.message,
+            details: error.details,
+          },
+        }),
+        { status: error.status, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const message = error instanceof Error ? error.message : 'Unknown error';
+
+    return new Response(
+      JSON.stringify({
+        error: {
+          code: 'INTERNAL_ERROR',
+          message: 'An internal error occurred',
+          details: message,
+        },
+      }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
 }

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -43,6 +43,7 @@ import { hasProviderByokForModel } from "@/lib/services/accessGateService";
 import { getUIMessageText } from "@/lib/message-utils";
 
 type ChatUIMessage = UIMessage & {
+  createdAt?: Date | string;
   hasWebSearch?: boolean;
   webSearchContextSize?: 'low' | 'medium' | 'high';
 };
@@ -242,6 +243,7 @@ export default function Chat() {
       id: msg.id,
       role: msg.role as ChatUIMessage['role'],
       parts: msg.parts,
+      createdAt: msg.createdAt,
       hasWebSearch: msg.hasWebSearch,
       webSearchContextSize: msg.webSearchContextSize,
     }));

--- a/components/image-modal.tsx
+++ b/components/image-modal.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import React from 'react';
-import { Download, X } from 'lucide-react';
+import React, { useState } from 'react';
+import { Download, Loader2, X } from 'lucide-react';
+import { toast } from 'sonner';
 import { Dialog, DialogOverlay, DialogPortal } from '@/components/ui/dialog';
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { Button } from '@/components/ui/button';
-import { formatFileSize } from '@/lib/image-utils';
+import { downloadImageFromUrl, formatFileSize } from '@/lib/image-utils';
 import { cn } from '@/lib/utils';
 
 interface ImageModalProps {
@@ -31,17 +32,22 @@ export function ImageModal({
   metadata,
   detail
 }: ImageModalProps) {
-  const handleDownload = () => {
-    // Create a download link for the image
-    const link = document.createElement('a');
-    link.href = imageUrl;
-    link.download = filename || metadata?.filename || 'image';
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-  };
-
+  const [isDownloading, setIsDownloading] = useState(false);
   const displayFilename = filename || metadata?.filename || 'Uploaded image';
+
+  const handleDownload = async () => {
+    if (isDownloading) return;
+
+    setIsDownloading(true);
+    try {
+      await downloadImageFromUrl(imageUrl, displayFilename);
+    } catch (error) {
+      console.error('Error downloading image:', error);
+      toast.error(error instanceof Error ? error.message : 'Failed to download image');
+    } finally {
+      setIsDownloading(false);
+    }
+  };
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
@@ -80,10 +86,15 @@ export function ImageModal({
                   variant="outline"
                   size="sm"
                   onClick={handleDownload}
+                  disabled={isDownloading}
                   className="flex items-center space-x-2"
                   aria-label={`Download ${displayFilename}`}
                 >
-                  <Download className="h-4 w-4" />
+                  {isDownloading ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Download className="h-4 w-4" />
+                  )}
                   <span className="hidden sm:inline">Download</span>
                 </Button>
                 

--- a/lib/chat-store.ts
+++ b/lib/chat-store.ts
@@ -48,13 +48,11 @@ export async function saveMessages({
     if (dbMessages.length > 0) {
       const chatId = dbMessages[0].chatId;
 
-      // First delete any existing messages for this chat
-      await db
-        .delete(messages)
-        .where(eq(messages.chatId, chatId));
-
-      // Then insert the new messages
-      return await db.insert(messages).values(dbMessages);
+      // Replace chat messages atomically so a failed insert cannot leave an empty chat.
+      return await db.transaction(async (tx) => {
+        await tx.delete(messages).where(eq(messages.chatId, chatId));
+        return tx.insert(messages).values(dbMessages);
+      });
     }
     return null;
   } catch (error) {

--- a/lib/chat-store.ts
+++ b/lib/chat-store.ts
@@ -9,6 +9,7 @@ import type { TextUIPart, ToolInvocationUIPart, ImageUIPart, WebSearchCitation }
 import type { ReasoningUIPart, SourceUIPart, FileUIPart, StepStartUIPart } from "@ai-sdk/ui-utils";
 
 type AIMessage = UIMessage & {
+  createdAt?: Date | string;
   hasWebSearch?: boolean;
   webSearchContextSize?: 'low' | 'medium' | 'high';
 };
@@ -62,11 +63,36 @@ export async function saveMessages({
   }
 }
 
+function parseMessageCreatedAt(createdAt: AIMessage['createdAt']): Date | null {
+  if (createdAt instanceof Date && !Number.isNaN(createdAt.getTime())) {
+    return createdAt;
+  }
+
+  if (typeof createdAt === 'string') {
+    const parsed = new Date(createdAt);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed;
+    }
+  }
+
+  return null;
+}
+
 // Function to convert AI messages to DB format
 export function convertToDBMessages(aiMessages: AIMessage[], chatId: string): DBMessage[] {
-  return aiMessages.map(msg => {
+  const baseTimestamp = Date.now();
+  let previousTimestamp = 0;
+
+  return aiMessages.map((msg, index) => {
     // Use existing id or generate a new one
     const messageId = msg.id || nanoid();
+    const parsedCreatedAt = parseMessageCreatedAt(msg.createdAt);
+    let createdAt = parsedCreatedAt ?? new Date(baseTimestamp + index);
+
+    if (createdAt.getTime() <= previousTimestamp) {
+      createdAt = new Date(previousTimestamp + 1);
+    }
+    previousTimestamp = createdAt.getTime();
 
     // If msg has parts, use them directly
     if (msg.parts?.length) {
@@ -77,7 +103,7 @@ export function convertToDBMessages(aiMessages: AIMessage[], chatId: string): DB
         parts: msg.parts,
         hasWebSearch: msg.hasWebSearch || false,
         webSearchContextSize: msg.webSearchContextSize || 'medium',
-        createdAt: new Date()
+        createdAt
       };
     }
 
@@ -93,7 +119,7 @@ export function convertToDBMessages(aiMessages: AIMessage[], chatId: string): DB
       parts,
       hasWebSearch: msg.hasWebSearch || false,
       webSearchContextSize: msg.webSearchContextSize || 'medium',
-      createdAt: new Date()
+      createdAt
     };
   });
 }

--- a/lib/chat/buildChatStreamPlan.ts
+++ b/lib/chat/buildChatStreamPlan.ts
@@ -1,0 +1,240 @@
+import {
+  stepCountIs,
+  type LanguageModel,
+  type UIMessage,
+} from 'ai';
+import {
+  getLanguageModelWithKeys,
+  createOpenRouterClientWithKey,
+  usesTagBasedReasoningExtraction,
+  wrapWithTagBasedReasoning,
+} from '@/ai/providers';
+import { getModelDefaults } from '@/lib/parameter-validation';
+import { cleanToolsForGoogleModels, isGoogleModel } from '@/lib/google-model-tools';
+import { getUIMessageText, userMessageRequestsImageCreation } from '@/lib/message-utils';
+import { resolveOpenRouterWebSearchRouteSetup } from '@/lib/services/openRouterWebSearchRouteSetup';
+import { ChatWebSearchService } from '@/lib/services/chatWebSearchService';
+import { ChatImageGenerationService } from '@/lib/services/chatImageGenerationService';
+import {
+  buildProjectContext,
+  formatProjectContextForSystemPrompt,
+} from '@/lib/services/projectContext';
+import { buildBaseChatTools, buildWebFetchPolicy } from '@/lib/chat/chatTools';
+import { buildDefaultSystemInstruction } from '@/lib/chat/systemInstruction';
+import { modelShouldDisableLogprobs } from '@/lib/chat/reasoningModels';
+import { prepareMessagesForModel } from '@/lib/chat/prepareMessagesForModel';
+import { createErrorResponse } from '@/lib/chat/createErrorResponse';
+import type { ChatPreflightContext } from '@/lib/chat/chatPreflight';
+import type { ChatRequestBody } from '@/lib/chat/chatRequest';
+import type { MCPServerResult } from '@/lib/services/chatMCPServerService';
+
+export interface ChatStreamPlan {
+  chatId: string;
+  modelInstance: LanguageModel;
+  effectiveWebSearchEnabled: boolean;
+  webSearchConfig: ChatPreflightContext['webSearchConfig'];
+  imageGenerationConfig: ChatPreflightContext['imageGenerationConfig'];
+  modelMessagesFinal: UIMessage[];
+  formattedMessages: ReturnType<
+    typeof import('@/lib/openrouter-utils').convertToOpenRouterFormat
+  >;
+  toolsToUse: Record<string, unknown>;
+  effectiveSystemInstruction: string;
+  effectiveTemperature: number;
+  effectiveMaxTokens: number;
+  shouldForceImageGenerationTool: boolean;
+  modelOptions: Record<string, unknown>;
+  openrouterUserId: string;
+  projectFileUrlByPath: Map<string, string>;
+}
+
+export type BuildChatStreamPlanResult =
+  | { ok: true; plan: ChatStreamPlan }
+  | { ok: false; response: Response };
+
+export async function buildChatStreamPlan(params: {
+  body: ChatRequestBody;
+  preflight: ChatPreflightContext;
+  chatId: string;
+  mcpResult: MCPServerResult;
+}): Promise<BuildChatStreamPlanResult> {
+  const { body, preflight, chatId, mcpResult } = params;
+  const {
+    authenticatedUser,
+    modelValidation,
+    accessPolicyFlags,
+    webSearchConfig,
+    imageGenerationConfig,
+  } = preflight;
+  const { selectedModel, messages, apiKeys, temperature, maxTokens, systemInstruction } =
+    body;
+  const selectedModelInfo = modelValidation.modelInfo;
+
+  const { modelMessagesFinal, formattedMessages } = await prepareMessagesForModel({
+    messages,
+    attachments: body.attachments,
+    selectedModel,
+    modelInfo: selectedModelInfo,
+  });
+
+  const projectFileUrlByPath = new Map<string, string>();
+  let projectContextAppendix: string | undefined;
+
+  try {
+    const projectContext = await buildProjectContext({
+      chatId,
+      userId: authenticatedUser.userId,
+    });
+    if (projectContext) {
+      for (const file of projectContext.files) {
+        if (file.filepath && file.url) {
+          projectFileUrlByPath.set(file.filepath, file.url);
+        }
+      }
+      projectContextAppendix = formatProjectContextForSystemPrompt(projectContext);
+    }
+  } catch (projectContextError) {
+    console.warn(`[Chat ${chatId}] Failed to build project context:`, projectContextError);
+  }
+
+  const webFetchPolicy = buildWebFetchPolicy(accessPolicyFlags);
+
+  let effectiveWebSearchEnabled = webSearchConfig.enabled;
+  const openrouterUserId = authenticatedUser.isAnonymous
+    ? `chatlima_anon_${authenticatedUser.userId}`
+    : `chatlima_user_${authenticatedUser.userId}`;
+
+  if (selectedModel.startsWith('openrouter/')) {
+    const openrouterApiKey =
+      apiKeys?.OPENROUTER_API_KEY || process.env.OPENROUTER_API_KEY;
+    if (!openrouterApiKey) {
+      console.error(
+        `[Chat ${chatId}] OpenRouter API key is missing for model ${selectedModel}`
+      );
+      return {
+        ok: false,
+        response: createErrorResponse(
+          'MISSING_API_KEY',
+          'OpenRouter API key is required for this model. Please configure your API key.',
+          400
+        ),
+      };
+    }
+    console.log(
+      `[Chat ${chatId}] OpenRouter API key available: ${openrouterApiKey.substring(0, 8)}...`
+    );
+  }
+
+  const webSearchSetup = resolveOpenRouterWebSearchRouteSetup({
+    selectedModel,
+    webSearchConfig,
+    modelInfo: selectedModelInfo,
+    apiKeys,
+    openrouterUserId,
+    getLanguageModelWithKeys,
+    createOpenRouterClientWithKey,
+    usesTagBasedReasoningExtraction,
+    wrapWithTagBasedReasoning,
+  });
+
+  effectiveWebSearchEnabled = webSearchSetup.effectiveWebSearchEnabled;
+  const modelOptions = { ...webSearchSetup.modelOptions };
+
+  if (modelShouldDisableLogprobs(selectedModel)) {
+    modelOptions.logprobs = false;
+  }
+
+  const baseTools = buildBaseChatTools({
+    mcpTools: mcpResult.tools as Record<string, unknown>,
+    messages,
+    projectFileUrlByPath,
+    accessPolicyFlags,
+  });
+
+  const allTools = {
+    ...baseTools,
+    ...webSearchSetup.openRouterServerTools,
+    ...ChatImageGenerationService.buildOpenRouterServerTools(
+      imageGenerationConfig,
+      apiKeys?.OPENROUTER_API_KEY || process.env.OPENROUTER_API_KEY
+    ),
+  };
+
+  const toolsToUse =
+    isGoogleModel(selectedModel) && Object.keys(allTools).length > 0
+      ? cleanToolsForGoogleModels(
+          allTools as Parameters<typeof cleanToolsForGoogleModels>[0]
+        )
+      : allTools;
+
+  const lastUserMessageText = (() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === 'user') {
+        return getUIMessageText(messages[i]);
+      }
+    }
+    return '';
+  })();
+
+  const userRequestedImageCreation =
+    imageGenerationConfig.enabled &&
+    userMessageRequestsImageCreation(lastUserMessageText);
+
+  const shouldForceImageGenerationTool =
+    userRequestedImageCreation &&
+    ChatImageGenerationService.modelSupportsForcedToolChoice(selectedModel);
+
+  const modelDefaults = getModelDefaults(selectedModelInfo);
+  const effectiveTemperature =
+    temperature !== undefined ? temperature : modelDefaults.temperature;
+  const effectiveMaxTokens =
+    maxTokens !== undefined ? maxTokens : modelDefaults.maxTokens;
+
+  const effectiveSystemInstruction = buildDefaultSystemInstruction({
+    systemInstruction,
+    webFetchEnabled: webFetchPolicy.enabled,
+    webSearchUseAgenticServerTools: webSearchConfig.useAgenticServerTools,
+    effectiveWebSearchEnabled,
+    imageGenerationEnabled: imageGenerationConfig.enabled,
+    projectContextAppendix,
+  });
+
+  if (webSearchConfig.enabled) {
+    console.log(
+      `[Web Search] ENABLED (${webSearchConfig.useAgenticServerTools ? 'agentic server tools' : 'legacy :online plugin'}) with context size: ${webSearchConfig.contextSize}`
+    );
+  } else {
+    console.log('[Web Search] DISABLED');
+  }
+
+  if (imageGenerationConfig.enabled) {
+    console.log(
+      `[Image Generation] ENABLED (model: ${imageGenerationConfig.model}, quality: ${imageGenerationConfig.quality}, aspect: ${imageGenerationConfig.aspectRatio})`
+    );
+  } else if (body.imageGeneration.enabled) {
+    console.log(`[Image Generation] Requested but not available for ${selectedModel}`);
+  } else {
+    console.log('[Image Generation] DISABLED');
+  }
+
+  return {
+    ok: true,
+    plan: {
+      chatId,
+      modelInstance: webSearchSetup.modelInstance as LanguageModel,
+      effectiveWebSearchEnabled,
+      webSearchConfig,
+      imageGenerationConfig,
+      modelMessagesFinal,
+      formattedMessages,
+      toolsToUse,
+      effectiveSystemInstruction,
+      effectiveTemperature,
+      effectiveMaxTokens,
+      shouldForceImageGenerationTool,
+      modelOptions,
+      openrouterUserId,
+      projectFileUrlByPath,
+    },
+  };
+}

--- a/lib/chat/chatPreflight.ts
+++ b/lib/chat/chatPreflight.ts
@@ -1,0 +1,248 @@
+import { getSubscriptionTypeByExternalId } from '@/lib/polar';
+import { getAccessPolicyFlags } from '@/lib/config/access-policy';
+import { canUserChat, hasProviderByokForModel } from '@/lib/services/accessGateService';
+import { ChatAuthenticationService } from '@/lib/services/chatAuthenticationService';
+import { ChatCreditValidationService } from '@/lib/services/chatCreditValidationService';
+import { ChatModelValidationService } from '@/lib/services/chatModelValidationService';
+import { ChatWebSearchService } from '@/lib/services/chatWebSearchService';
+import { ChatImageGenerationService } from '@/lib/services/chatImageGenerationService';
+import { DailyMessageUsageService } from '@/lib/services/dailyMessageUsageService';
+import { resolveAllowedImageModel } from '@/lib/constants/image-generation-models';
+import { createErrorResponse } from '@/lib/chat/createErrorResponse';
+import type { ChatRequestBody } from '@/lib/chat/chatRequest';
+import type { ModelValidationResult } from '@/lib/services/chatModelValidationService';
+import type { AuthenticatedUser } from '@/lib/services/chatAuthenticationService';
+import type { CreditValidationResult } from '@/lib/services/chatCreditValidationService';
+import type { WebSearchResult } from '@/lib/services/chatWebSearchService';
+import type { AccessPolicyFlags } from '@/lib/config/access-policy';
+
+export interface ChatPreflightContext {
+  authenticatedUser: AuthenticatedUser;
+  modelValidation: ModelValidationResult;
+  accessPolicyFlags: AccessPolicyFlags;
+  isUsingOwnApiKeys: boolean;
+  creditValidation: CreditValidationResult;
+  webSearchConfig: WebSearchResult;
+  imageGenerationConfig: ReturnType<
+    typeof ChatImageGenerationService.validateAndConfigureImageGeneration
+  >;
+  resolvedImageGenerationModel: string;
+}
+
+export type ChatPreflightResult =
+  | { ok: true; context: ChatPreflightContext }
+  | { ok: false; response: Response };
+
+function buildCreditContext(
+  body: ChatRequestBody,
+  authenticatedUser: AuthenticatedUser,
+  isUsingOwnApiKeys: boolean,
+  hasCredits?: boolean
+) {
+  return {
+    userId: authenticatedUser.userId,
+    isAnonymous: authenticatedUser.isAnonymous,
+    polarCustomerId: authenticatedUser.polarCustomerId,
+    selectedModel: body.selectedModel,
+    isUsingOwnApiKeys,
+    isFreeModel: body.selectedModel.endsWith(':free'),
+    webSearchEnabled: body.webSearch.enabled,
+    estimatedTokens: 30,
+    ...(hasCredits !== undefined ? { hasCredits } : {}),
+  };
+}
+
+export async function runChatPreflight(
+  req: Request,
+  body: ChatRequestBody
+): Promise<ChatPreflightResult> {
+  const authenticatedUser = await ChatAuthenticationService.authenticateUser(req);
+
+  const modelValidation = await ChatModelValidationService.validateAndConfigureModel({
+    selectedModel: body.selectedModel,
+    temperature: body.temperature,
+    maxTokens: body.maxTokens,
+    systemInstruction: body.systemInstruction,
+  });
+
+  const accessPolicyFlags = getAccessPolicyFlags();
+  let hasPaidSubscription = false;
+
+  if (!authenticatedUser.isAnonymous) {
+    try {
+      const subscriptionType = await getSubscriptionTypeByExternalId(
+        authenticatedUser.userId
+      );
+      hasPaidSubscription =
+        subscriptionType === 'monthly' || subscriptionType === 'yearly';
+    } catch (error) {
+      console.warn(
+        '[AccessGate] Failed to resolve subscription type, treating as unsubscribed:',
+        error
+      );
+    }
+  }
+
+  const gateResult = canUserChat({
+    isAnonymous: authenticatedUser.isAnonymous,
+    hasPaidSubscription,
+    selectedModel: body.selectedModel,
+    apiKeys: body.apiKeys,
+    flags: accessPolicyFlags,
+  });
+
+  if (!gateResult.allowed) {
+    console.warn('[AccessGate] Chat request blocked', {
+      reason: gateResult.reason,
+      userId: authenticatedUser.userId,
+      isAnonymous: authenticatedUser.isAnonymous,
+      selectedModel: body.selectedModel,
+    });
+    return {
+      ok: false,
+      response: createErrorResponse(
+        gateResult.reason,
+        gateResult.reason === 'PAYWALL_BYOK_REQUIRED'
+          ? "Paid subscription required, or add a BYOK API key for this model's provider."
+          : 'Paid subscription required to chat.',
+        402
+      ),
+    };
+  }
+
+  const isUsingOwnApiKeys = hasProviderByokForModel(
+    body.selectedModel,
+    body.apiKeys
+  );
+
+  const creditValidation = await ChatCreditValidationService.validateCredits(
+    buildCreditContext(body, authenticatedUser, isUsingOwnApiKeys)
+  );
+
+  if (!accessPolicyFlags.billingEnforced && !creditValidation.hasCredits) {
+    const limitCheck = await DailyMessageUsageService.checkDailyLimit(
+      authenticatedUser.userId
+    );
+
+    if (limitCheck.hasReachedLimit) {
+      console.log(`[Chat] Daily message limit reached:`, {
+        userId: authenticatedUser.userId,
+        isAnonymous: authenticatedUser.isAnonymous,
+        messageCount: limitCheck.messageCount,
+        limit: limitCheck.limit,
+        remaining: limitCheck.remaining,
+      });
+      return {
+        ok: false,
+        response: createErrorResponse(
+          'MESSAGE_LIMIT_REACHED',
+          'Message limit reached',
+          429,
+          JSON.stringify({
+            limit: limitCheck.limit,
+            remaining: limitCheck.remaining,
+            messageCount: limitCheck.messageCount,
+          })
+        ),
+      };
+    }
+
+    try {
+      const incrementResult = await DailyMessageUsageService.incrementDailyUsage(
+        authenticatedUser.userId,
+        authenticatedUser.isAnonymous
+      );
+      console.log(`[Chat] Incremented daily message usage:`, {
+        userId: authenticatedUser.userId,
+        isAnonymous: authenticatedUser.isAnonymous,
+        newCount: incrementResult.newCount,
+        date: incrementResult.date,
+        remaining: limitCheck.remaining - 1,
+      });
+    } catch (error) {
+      console.error(`[Chat] Failed to increment daily usage:`, error);
+    }
+  } else {
+    console.log(
+      `[Chat] Skipping daily usage increment - user has credits (${creditValidation.actualCredits})`
+    );
+  }
+
+  const creditCtxWithHasCredits = buildCreditContext(
+    body,
+    authenticatedUser,
+    isUsingOwnApiKeys,
+    creditValidation.hasCredits
+  );
+
+  await ChatCreditValidationService.validateFreeModelAccess(creditCtxWithHasCredits);
+  await ChatCreditValidationService.validatePremiumModelAccess(creditCtxWithHasCredits);
+
+  const webSearchConfig = ChatWebSearchService.validateAndConfigureWebSearch(
+    {
+      webSearch: body.webSearch,
+      selectedModel: body.selectedModel,
+      isUsingOwnApiKeys,
+      isAnonymous: authenticatedUser.isAnonymous,
+      actualCredits: creditValidation.actualCredits,
+      modelInfo: modelValidation.modelInfo,
+    },
+    {
+      agenticWebToolsEnabled: accessPolicyFlags.openrouterAgenticWebToolsEnabled,
+    }
+  );
+
+  const resolvedImageGenerationModel = resolveAllowedImageModel(
+    body.imageGeneration.model
+  );
+
+  const imageGenPayload = {
+    enabled: body.imageGeneration.enabled,
+    quality: body.imageGeneration.quality ?? ('medium' as const),
+    aspectRatio: body.imageGeneration.aspectRatio ?? '1:1',
+    outputFormat: body.imageGeneration.outputFormat ?? ('png' as const),
+    model: resolvedImageGenerationModel,
+  };
+
+  const imageGenerationConfig =
+    ChatImageGenerationService.validateAndConfigureImageGeneration({
+      imageGeneration: imageGenPayload,
+      selectedModel: body.selectedModel,
+      isUsingOwnApiKeys,
+      isAnonymous: authenticatedUser.isAnonymous,
+      actualCredits: creditValidation.actualCredits,
+      modelInfo: modelValidation.modelInfo,
+    });
+
+  try {
+    ChatImageGenerationService.validateImageGenerationRequest({
+      imageGeneration: imageGenPayload,
+      selectedModel: body.selectedModel,
+      isUsingOwnApiKeys,
+      isAnonymous: authenticatedUser.isAnonymous,
+      actualCredits: creditValidation.actualCredits,
+      modelInfo: modelValidation.modelInfo,
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Image generation is not available.';
+    return {
+      ok: false,
+      response: createErrorResponse('FEATURE_RESTRICTED', message, 403),
+    };
+  }
+
+  return {
+    ok: true,
+    context: {
+      authenticatedUser,
+      modelValidation,
+      accessPolicyFlags,
+      isUsingOwnApiKeys,
+      creditValidation,
+      webSearchConfig,
+      imageGenerationConfig,
+      resolvedImageGenerationModel,
+    },
+  };
+}

--- a/lib/chat/chatRequest.ts
+++ b/lib/chat/chatRequest.ts
@@ -1,0 +1,94 @@
+import type { UIMessage } from 'ai';
+import type { ImageGenerationOptions } from '@/lib/services/chatImageGenerationService';
+
+export interface KeyValuePair {
+  key: string;
+  value: string;
+}
+
+export interface MCPServerConfig {
+  url: string;
+  type: 'sse' | 'stdio' | 'streamable-http';
+  command?: string;
+  args?: string[];
+  env?: KeyValuePair[];
+  headers?: KeyValuePair[];
+  useOAuth?: boolean;
+  id?: string;
+  oauthTokens?: {
+    access_token: string;
+    refresh_token?: string;
+    expires_in?: number;
+    token_type?: string;
+  };
+}
+
+export interface WebSearchOptions {
+  enabled: boolean;
+  contextSize: 'low' | 'medium' | 'high';
+}
+
+export interface ImageGenerationRequestOptions {
+  enabled: boolean;
+  quality?: ImageGenerationOptions['quality'];
+  aspectRatio?: string;
+  outputFormat?: ImageGenerationOptions['outputFormat'];
+  model?: string;
+}
+
+export interface ChatRequestBody {
+  action?: string;
+  messages: UIMessage[];
+  chatId?: string;
+  selectedModel: string;
+  mcpServers: MCPServerConfig[];
+  webSearch: WebSearchOptions;
+  imageGeneration: ImageGenerationRequestOptions;
+  apiKeys: Record<string, string>;
+  attachments: Array<{
+    name: string;
+    contentType: string;
+    url: string;
+  }>;
+  temperature?: number;
+  maxTokens?: number;
+  systemInstruction?: string;
+}
+
+const DEFAULT_IMAGE_GENERATION: ImageGenerationRequestOptions = {
+  enabled: false,
+  quality: 'medium',
+  aspectRatio: '1:1',
+  outputFormat: 'png',
+  model: 'openai/gpt-5-image',
+};
+
+export function parseChatRequestBody(body: unknown): ChatRequestBody {
+  const raw = (body ?? {}) as Record<string, unknown>;
+
+  return {
+    action: typeof raw.action === 'string' ? raw.action : undefined,
+    messages: (raw.messages as UIMessage[]) ?? [],
+    chatId: typeof raw.chatId === 'string' ? raw.chatId : undefined,
+    selectedModel: String(raw.selectedModel ?? ''),
+    mcpServers: (raw.mcpServers as MCPServerConfig[]) ?? [],
+    webSearch: (raw.webSearch as WebSearchOptions) ?? {
+      enabled: false,
+      contextSize: 'medium',
+    },
+    imageGeneration: {
+      ...DEFAULT_IMAGE_GENERATION,
+      ...((raw.imageGeneration as ImageGenerationRequestOptions) ?? {}),
+    },
+    apiKeys: (raw.apiKeys as Record<string, string>) ?? {},
+    attachments:
+      (raw.attachments as ChatRequestBody['attachments']) ?? [],
+    temperature:
+      typeof raw.temperature === 'number' ? raw.temperature : undefined,
+    maxTokens: typeof raw.maxTokens === 'number' ? raw.maxTokens : undefined,
+    systemInstruction:
+      typeof raw.systemInstruction === 'string'
+        ? raw.systemInstruction
+        : undefined,
+  };
+}

--- a/lib/chat/chatStreamFinalizer.ts
+++ b/lib/chat/chatStreamFinalizer.ts
@@ -1,0 +1,455 @@
+import type { UIMessage, LanguageModelResponseMetadata } from 'ai';
+import { saveChat, saveMessages, convertToDBMessages } from '@/lib/chat-store';
+import { db } from '@/lib/db';
+import { messages as messagesTable } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
+import {
+  buildAssistantMessageForPersistence,
+  countPersistableDisplayParts,
+  createStreamFinishGate,
+  processMessagesForPersistence,
+} from '@/lib/chat-message-persistence';
+import {
+  extractGeneratedImageUrlsFromStreamEvent,
+} from '@/lib/message-utils';
+import { ChatWebSearchService } from '@/lib/services/chatWebSearchService';
+import { ChatImageGenerationService } from '@/lib/services/chatImageGenerationService';
+import { ChatTokenTrackingService } from '@/lib/services/chatTokenTrackingService';
+import { WEB_SEARCH_COST } from '@/lib/tokenCounter';
+import { hasProviderByokForModel } from '@/lib/services/accessGateService';
+import type { AuthenticatedUser } from '@/lib/services/chatAuthenticationService';
+import type { ModelValidationResult } from '@/lib/services/chatModelValidationService';
+import type { WebSearchResult } from '@/lib/services/chatWebSearchService';
+import type { ChatStreamPlan } from '@/lib/chat/buildChatStreamPlan';
+import {
+  computeStreamTokenUsage,
+  computeTokensPerSecond,
+  estimateTimeToFirstTokenMs,
+} from '@/lib/chat/streamTokenUsage';
+import { logDiagnostic } from '@/lib/utils/performantLogging';
+
+export interface OpenRouterStreamResponse extends LanguageModelResponseMetadata {
+  readonly messages: Array<
+    UIMessage | { role: string; content?: string | unknown[]; parts?: unknown[]; id?: string }
+  >;
+  annotations?: Array<{ type: string; url_citation: unknown }>;
+  body?: unknown;
+}
+
+export interface ChatStreamFinalizerParams {
+  chatId: string;
+  requestId: string;
+  requestStartTime: number;
+  clientMessages: UIMessage[];
+  authenticatedUser: AuthenticatedUser;
+  selectedModel: string;
+  apiKeys: Record<string, string>;
+  isAnonymous: boolean;
+  plan: ChatStreamPlan;
+  modelValidation: ModelValidationResult;
+  titleGenerationPromise?: Promise<string>;
+  getRemainingCreditsByExternalId: (userId: string) => Promise<number | null>;
+}
+
+const UI_FINISH_WAIT_MS = 6000;
+const UI_FINISH_POLL_MS = 200;
+
+export function createChatStreamFinalizer(params: ChatStreamFinalizerParams) {
+  const {
+    chatId,
+    requestId,
+    requestStartTime,
+    clientMessages,
+    authenticatedUser,
+    selectedModel,
+    apiKeys,
+    plan,
+    modelValidation,
+    titleGenerationPromise,
+    getRemainingCreditsByExternalId,
+  } = params;
+
+  const streamFinishGate = createStreamFinishGate();
+
+  const state = {
+    tokenUsageData: null as { inputTokens: number; outputTokens: number } | null,
+    messagesSavedSuccessfully: false,
+    savedAssistantPartCount: 0,
+    finalAssistantMessageId: nanoid(),
+    uiResponseMessage: null as UIMessage | null,
+    streamFinishEvent: null as Record<string, unknown> | null,
+    streamFinishResponse: null as OpenRouterStreamResponse | null,
+    uiFinishResolved: false,
+  };
+
+  let persistInFlight: Promise<void> = Promise.resolve();
+  let timeToFirstTokenMs: number | null = null;
+  let streamingStartTime: Date | null = null;
+  let tokensPerSecond: number | null = null;
+
+  const persistAssistantMessages = async (
+    source: 'ui' | 'stream',
+    responseMessage?: UIMessage
+  ) => {
+    const runPersist = async () => {
+      const uiMsg = responseMessage ?? state.uiResponseMessage;
+      const event = state.streamFinishEvent;
+      const response = state.streamFinishResponse;
+
+      if (!uiMsg?.parts?.length && !(event?.text as string | undefined)) {
+        return;
+      }
+
+      try {
+        const trailingAssistant = clientMessages[clientMessages.length - 1];
+        const historyMessages =
+          trailingAssistant?.role === 'assistant'
+            ? clientMessages.slice(0, -1)
+            : clientMessages;
+
+        const responseAssistantId = response?.messages
+          ?.filter((m) => m.role === 'assistant')
+          .pop()?.id as string | undefined;
+
+        const assistantMessage = buildAssistantMessageForPersistence({
+          clientMessages,
+          uiResponseMessage: uiMsg ?? null,
+          streamText: (event?.text as string) || '',
+          reasoningText: event?.reasoningText as string | undefined,
+          responseAssistantId,
+        });
+
+        if (state.messagesSavedSuccessfully) {
+          const newCount = countPersistableDisplayParts(assistantMessage.parts);
+          if (newCount <= state.savedAssistantPartCount) {
+            return;
+          }
+        }
+
+        const webSearchInvocationCount = event
+          ? ChatWebSearchService.resolveWebSearchInvocationCount({
+              steps: event.steps as Parameters<
+                typeof ChatWebSearchService.resolveWebSearchInvocationCount
+              >[0]['steps'],
+              usage: event.usage as Parameters<
+                typeof ChatWebSearchService.resolveWebSearchInvocationCount
+              >[0]['usage'],
+            })
+          : 0;
+        const webSearchWasUsed = event
+          ? ChatWebSearchService.messageUsedWebSearch({
+              steps: event.steps as Parameters<
+                typeof ChatWebSearchService.messageUsedWebSearch
+              >[0]['steps'],
+              usage: event.usage as Parameters<
+                typeof ChatWebSearchService.messageUsedWebSearch
+              >[0]['usage'],
+              hasCitationAnnotations: (response?.annotations?.length || 0) > 0,
+            })
+          : false;
+
+        const imageUrlsFromStream = extractGeneratedImageUrlsFromStreamEvent(
+          event,
+          response
+        );
+        const imageGenerationWasUsed =
+          plan.imageGenerationConfig.enabled &&
+          (ChatImageGenerationService.countImageGenerationInvocations(
+            event?.steps as Parameters<
+              typeof ChatImageGenerationService.countImageGenerationInvocations
+            >[0]
+          ) > 0 ||
+            imageUrlsFromStream.length > 0);
+
+        const processedMessages = processMessagesForPersistence({
+          historyMessages,
+          assistantMessage,
+          annotations: response?.annotations as Parameters<
+            typeof processMessagesForPersistence
+          >[0]['annotations'],
+          webSearch: {
+            useAgenticServerTools: plan.webSearchConfig.useAgenticServerTools,
+            enabled: plan.effectiveWebSearchEnabled,
+            wasUsed: webSearchWasUsed,
+            invocationCount: webSearchInvocationCount,
+          },
+          imageGeneration: plan.imageGenerationConfig.enabled
+            ? {
+                enabled: true,
+                wasUsed: imageGenerationWasUsed,
+                imageUrls: imageUrlsFromStream,
+              }
+            : undefined,
+        });
+
+        const processedAssistant = processedMessages.find((m) => m.role === 'assistant');
+        if (processedAssistant && source === 'ui') {
+          state.uiResponseMessage = processedAssistant;
+        }
+
+        const logTag = source === 'ui' ? 'uiOnFinish' : 'onFinish';
+
+        const dbMessages = (
+          convertToDBMessages(processedMessages as UIMessage[], chatId) as Array<{
+            id?: string;
+            role: string;
+            [key: string]: unknown;
+          }>
+        ).map((msg) => ({
+          ...msg,
+          hasWebSearch:
+            plan.effectiveWebSearchEnabled &&
+            msg.role === 'assistant' &&
+            (plan.webSearchConfig.useAgenticServerTools
+              ? webSearchWasUsed
+              : (response?.annotations?.length || 0) > 0),
+          webSearchContextSize: plan.webSearchConfig.enabled
+            ? plan.webSearchConfig.contextSize
+            : undefined,
+        }));
+
+        const savedAssistant = dbMessages.find((msg) => msg.role === 'assistant');
+        state.finalAssistantMessageId =
+          savedAssistant?.id ||
+          (response?.messages
+            ?.filter((m) => m.role === 'assistant')
+            .pop()?.id as string) ||
+          state.finalAssistantMessageId;
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await saveMessages({ messages: dbMessages as any });
+        state.messagesSavedSuccessfully = true;
+        state.savedAssistantPartCount = countPersistableDisplayParts(
+          processedAssistant?.parts ?? assistantMessage.parts
+        );
+        console.log(`[Chat ${chatId}][${logTag}] Successfully saved messages.`);
+
+        await saveChat({
+          id: chatId,
+          userId: authenticatedUser.userId,
+          messages: processedMessages as Parameters<typeof saveChat>[0]['messages'],
+          selectedModel,
+          apiKeys,
+          isAnonymous: authenticatedUser.isAnonymous,
+          titleGenerationPromise,
+        });
+      } catch (persistError) {
+        const logTag = source === 'ui' ? 'uiOnFinish' : 'onFinish';
+        console.error(`[Chat ${chatId}][${logTag}] Failed to persist messages:`, persistError);
+      }
+    };
+
+    persistInFlight = persistInFlight.then(runPersist, runPersist);
+    await persistInFlight;
+  };
+
+  const waitForUiFinish = (): Promise<void> => {
+    if (state.uiFinishResolved) {
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      const deadline = Date.now() + UI_FINISH_WAIT_MS;
+      const tick = () => {
+        if (state.uiFinishResolved || state.uiResponseMessage) {
+          resolve();
+          return;
+        }
+        if (Date.now() >= deadline) {
+          resolve();
+          return;
+        }
+        setTimeout(tick, UI_FINISH_POLL_MS);
+      };
+      tick();
+    });
+  };
+
+  const trackTokenUsage = async (
+    event: Record<string, unknown>,
+    response: OpenRouterStreamResponse
+  ) => {
+    const isUsingOwnApiKeys = hasProviderByokForModel(selectedModel, apiKeys);
+    let actualCredits: number | null = null;
+
+    if (!authenticatedUser.isAnonymous && authenticatedUser.userId) {
+      try {
+        actualCredits = await getRemainingCreditsByExternalId(authenticatedUser.userId);
+      } catch (error) {
+        logDiagnostic('TOKEN_TRACKING_WARNING', 'Error getting credits in stream finish', {
+          requestId,
+          userId: authenticatedUser.userId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    const isFreeModel = selectedModel.endsWith(':free');
+    const shouldDeductCredits =
+      !authenticatedUser.isAnonymous &&
+      !isUsingOwnApiKeys &&
+      !isFreeModel &&
+      actualCredits !== null &&
+      actualCredits > 0;
+
+    let additionalCost = 0;
+    if (shouldDeductCredits) {
+      additionalCost =
+        ChatWebSearchService.computeWebSearchCreditCost({
+          webSearchEnabled: plan.webSearchConfig.enabled,
+          useAgenticServerTools: plan.webSearchConfig.useAgenticServerTools,
+          isUsingOwnApiKeys,
+          shouldDeductCredits,
+          steps: event.steps as Parameters<
+            typeof ChatWebSearchService.computeWebSearchCreditCost
+          >[0]['steps'],
+          usage: event.usage as Parameters<
+            typeof ChatWebSearchService.computeWebSearchCreditCost
+          >[0]['usage'],
+          hasCitationAnnotations: (response.annotations?.length || 0) > 0,
+        }) +
+        ChatImageGenerationService.computeImageGenerationCreditCost({
+          imageGenerationEnabled: plan.imageGenerationConfig.enabled,
+          isUsingOwnApiKeys,
+          shouldDeductCredits,
+          model: plan.imageGenerationConfig.model,
+          steps: event.steps as Parameters<
+            typeof ChatImageGenerationService.computeImageGenerationCreditCost
+          >[0]['steps'],
+        });
+    }
+
+    if (!state.tokenUsageData) {
+      state.tokenUsageData = computeStreamTokenUsage({
+        event: event as Parameters<typeof computeStreamTokenUsage>[0]['event'],
+        response: response as Parameters<typeof computeStreamTokenUsage>[0]['response'],
+        modelMessagesFinal: plan.modelMessagesFinal,
+        effectiveSystemInstruction: plan.effectiveSystemInstruction,
+        requestId,
+      });
+    }
+
+    await ChatTokenTrackingService.processTokenTracking(
+      {
+        userId: authenticatedUser.userId,
+        chatId,
+        messageId: undefined,
+        selectedModel,
+        provider: selectedModel.split('/')[0],
+        polarCustomerId: authenticatedUser.polarCustomerId,
+        isAnonymous: authenticatedUser.isAnonymous,
+        isUsingOwnApiKeys,
+        shouldDeductCredits,
+        webSearchEnabled: plan.webSearchConfig.enabled,
+        webSearchCost: WEB_SEARCH_COST,
+        additionalCost,
+        apiKeys,
+        modelInfo: modelValidation.modelInfo ?? undefined,
+      },
+      response,
+      event,
+      requestStartTime,
+      timeToFirstTokenMs ?? undefined,
+      streamingStartTime ?? undefined
+    );
+  };
+
+  const finalizeAfterStream = async () => {
+    if (!state.streamFinishEvent || !state.streamFinishResponse) {
+      return;
+    }
+
+    await Promise.race([
+      waitForUiFinish(),
+      streamFinishGate.readyPromise.then(() => undefined),
+    ]);
+
+    if (state.messagesSavedSuccessfully) {
+      if (state.uiResponseMessage) {
+        await persistAssistantMessages('stream', state.uiResponseMessage);
+      }
+      return;
+    }
+
+    await persistAssistantMessages('stream', state.uiResponseMessage ?? undefined);
+  };
+
+  return {
+    streamFinishGate,
+    recordFirstToken() {
+      if (timeToFirstTokenMs === null) {
+        const now = Date.now();
+        timeToFirstTokenMs = now - requestStartTime;
+        if (streamingStartTime === null) {
+          streamingStartTime = new Date();
+        }
+      }
+    },
+    getTimingMetrics: () => ({
+      timeToFirstTokenMs,
+      streamingStartTime,
+      tokensPerSecond,
+    }),
+    async handleUiStreamFinish(responseMessage: UIMessage) {
+      state.uiResponseMessage = responseMessage;
+      state.uiFinishResolved = true;
+      await persistAssistantMessages('ui', responseMessage);
+    },
+    handleStreamTextFinish(event: Record<string, unknown>, response: OpenRouterStreamResponse) {
+      state.streamFinishEvent = event;
+      state.streamFinishResponse = response;
+      streamFinishGate.notify(event, response);
+
+      state.finalAssistantMessageId =
+        (response.messages?.filter((m) => m.role === 'assistant').pop()?.id as string) ||
+        state.finalAssistantMessageId;
+    },
+    async processStreamFinish(event: Record<string, unknown>, response: OpenRouterStreamResponse) {
+      if (!response?.messages) {
+        console.error(`[Chat ${chatId}][onFinish] Invalid response structure:`, response);
+        return;
+      }
+
+      state.streamFinishEvent = event;
+      state.streamFinishResponse = response;
+      streamFinishGate.notify(event, response);
+
+      state.finalAssistantMessageId =
+        (response.messages?.filter((m) => m.role === 'assistant').pop()?.id as string) ||
+        state.finalAssistantMessageId;
+
+      timeToFirstTokenMs = estimateTimeToFirstTokenMs({
+        timeToFirstTokenMs,
+        eventDurationMs: event.durationMs as number | undefined,
+        requestStartTime,
+      });
+
+      state.tokenUsageData = computeStreamTokenUsage({
+        event: event as Parameters<typeof computeStreamTokenUsage>[0]['event'],
+        response: response as Parameters<typeof computeStreamTokenUsage>[0]['response'],
+        modelMessagesFinal: plan.modelMessagesFinal,
+        effectiveSystemInstruction: plan.effectiveSystemInstruction,
+        requestId,
+      });
+
+      tokensPerSecond = computeTokensPerSecond({
+        timeToFirstTokenMs,
+        outputTokens: state.tokenUsageData.outputTokens,
+        requestStartTime,
+      });
+
+      void (async () => {
+        try {
+          await finalizeAfterStream();
+        } catch (persistError) {
+          console.error(`[Chat ${chatId}][onFinish] Failed stream persistence:`, persistError);
+        }
+        try {
+          await trackTokenUsage(event, response);
+        } catch (tokenError) {
+          console.error(`[Chat ${chatId}][onFinish] Failed token tracking:`, tokenError);
+        }
+      })();
+    },
+  };
+}

--- a/lib/chat/chatStreamFinalizer.ts
+++ b/lib/chat/chatStreamFinalizer.ts
@@ -7,7 +7,6 @@ import { nanoid } from 'nanoid';
 import {
   buildAssistantMessageForPersistence,
   countPersistableDisplayParts,
-  createStreamFinishGate,
   processMessagesForPersistence,
 } from '@/lib/chat-message-persistence';
 import {
@@ -70,8 +69,6 @@ export function createChatStreamFinalizer(params: ChatStreamFinalizerParams) {
     getRemainingCreditsByExternalId,
   } = params;
 
-  const streamFinishGate = createStreamFinishGate();
-
   const state = {
     tokenUsageData: null as { inputTokens: number; outputTokens: number } | null,
     messagesSavedSuccessfully: false,
@@ -80,7 +77,6 @@ export function createChatStreamFinalizer(params: ChatStreamFinalizerParams) {
     uiResponseMessage: null as UIMessage | null,
     streamFinishEvent: null as Record<string, unknown> | null,
     streamFinishResponse: null as OpenRouterStreamResponse | null,
-    uiFinishResolved: false,
   };
 
   let persistInFlight: Promise<void> = Promise.resolve();
@@ -98,6 +94,9 @@ export function createChatStreamFinalizer(params: ChatStreamFinalizerParams) {
       const response = state.streamFinishResponse;
 
       if (!uiMsg?.parts?.length && !(event?.text as string | undefined)) {
+        console.warn(
+          `[Chat ${chatId}][${source === 'ui' ? 'uiOnFinish' : 'onFinish'}] Skipping persist: no UI parts and no stream text yet`
+        );
         return;
       }
 
@@ -190,6 +189,15 @@ export function createChatStreamFinalizer(params: ChatStreamFinalizerParams) {
 
         const logTag = source === 'ui' ? 'uiOnFinish' : 'onFinish';
 
+        console.log(`[Chat ${chatId}][${logTag}] Persisting assistant parts:`, {
+          partTypes:
+            processedMessages
+              .find((m) => m.role === 'assistant')
+              ?.parts?.map((p) => p.type) ?? [],
+          partCount:
+            processedMessages.find((m) => m.role === 'assistant')?.parts?.length ?? 0,
+        });
+
         const dbMessages = (
           convertToDBMessages(processedMessages as UIMessage[], chatId) as Array<{
             id?: string;
@@ -242,27 +250,6 @@ export function createChatStreamFinalizer(params: ChatStreamFinalizerParams) {
 
     persistInFlight = persistInFlight.then(runPersist, runPersist);
     await persistInFlight;
-  };
-
-  const waitForUiFinish = (): Promise<void> => {
-    if (state.uiFinishResolved) {
-      return Promise.resolve();
-    }
-    return new Promise((resolve) => {
-      const deadline = Date.now() + UI_FINISH_WAIT_MS;
-      const tick = () => {
-        if (state.uiFinishResolved || state.uiResponseMessage) {
-          resolve();
-          return;
-        }
-        if (Date.now() >= deadline) {
-          resolve();
-          return;
-        }
-        setTimeout(tick, UI_FINISH_POLL_MS);
-      };
-      tick();
-    });
   };
 
   const trackTokenUsage = async (
@@ -359,10 +346,11 @@ export function createChatStreamFinalizer(params: ChatStreamFinalizerParams) {
       return;
     }
 
-    await Promise.race([
-      waitForUiFinish(),
-      streamFinishGate.readyPromise.then(() => undefined),
-    ]);
+    // UI onFinish usually follows with tool/image parts; wait like main branch (do not
+    // race streamFinishGate — it resolves on streamText onFinish and skips this wait).
+    for (let i = 0; i < UI_FINISH_WAIT_MS / UI_FINISH_POLL_MS && !state.uiResponseMessage; i++) {
+      await new Promise((resolve) => setTimeout(resolve, UI_FINISH_POLL_MS));
+    }
 
     if (state.messagesSavedSuccessfully) {
       if (state.uiResponseMessage) {
@@ -375,7 +363,6 @@ export function createChatStreamFinalizer(params: ChatStreamFinalizerParams) {
   };
 
   return {
-    streamFinishGate,
     recordFirstToken() {
       if (timeToFirstTokenMs === null) {
         const now = Date.now();
@@ -392,13 +379,11 @@ export function createChatStreamFinalizer(params: ChatStreamFinalizerParams) {
     }),
     async handleUiStreamFinish(responseMessage: UIMessage) {
       state.uiResponseMessage = responseMessage;
-      state.uiFinishResolved = true;
       await persistAssistantMessages('ui', responseMessage);
     },
     handleStreamTextFinish(event: Record<string, unknown>, response: OpenRouterStreamResponse) {
       state.streamFinishEvent = event;
       state.streamFinishResponse = response;
-      streamFinishGate.notify(event, response);
 
       state.finalAssistantMessageId =
         (response.messages?.filter((m) => m.role === 'assistant').pop()?.id as string) ||
@@ -412,7 +397,6 @@ export function createChatStreamFinalizer(params: ChatStreamFinalizerParams) {
 
       state.streamFinishEvent = event;
       state.streamFinishResponse = response;
-      streamFinishGate.notify(event, response);
 
       state.finalAssistantMessageId =
         (response.messages?.filter((m) => m.role === 'assistant').pop()?.id as string) ||

--- a/lib/chat/chatStreamFinalizer.ts
+++ b/lib/chat/chatStreamFinalizer.ts
@@ -1,3 +1,4 @@
+import { after } from 'next/server';
 import type { UIMessage, LanguageModelResponseMetadata } from 'ai';
 import { saveChat, saveMessages, convertToDBMessages } from '@/lib/chat-store';
 import { db } from '@/lib/db';
@@ -54,6 +55,30 @@ export interface ChatStreamFinalizerParams {
 const UI_FINISH_WAIT_MS = 6000;
 const UI_FINISH_POLL_MS = 200;
 
+/** Persist client-side history (excluding in-flight assistant placeholder) before streaming. */
+export async function persistClientMessagesAtRequestStart(params: {
+  chatId: string;
+  clientMessages: UIMessage[];
+}): Promise<void> {
+  const { chatId, clientMessages } = params;
+  const trailingAssistant = clientMessages[clientMessages.length - 1];
+  const historyMessages =
+    trailingAssistant?.role === 'assistant'
+      ? clientMessages.slice(0, -1)
+      : clientMessages;
+
+  if (historyMessages.length === 0) {
+    return;
+  }
+
+  const dbMessages = convertToDBMessages(historyMessages, chatId);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await saveMessages({ messages: dbMessages as any });
+  console.log(
+    `[Chat ${chatId}][requestStart] Saved ${dbMessages.length} client message(s) before stream.`
+  );
+}
+
 export function createChatStreamFinalizer(params: ChatStreamFinalizerParams) {
   const {
     chatId,
@@ -93,9 +118,19 @@ export function createChatStreamFinalizer(params: ChatStreamFinalizerParams) {
       const event = state.streamFinishEvent;
       const response = state.streamFinishResponse;
 
-      if (!uiMsg?.parts?.length && !(event?.text as string | undefined)) {
+      const imageUrlsFromStreamPreview = event
+        ? extractGeneratedImageUrlsFromStreamEvent(event, response)
+        : [];
+      const canPersistFromStreamImages =
+        plan.imageGenerationConfig.enabled && imageUrlsFromStreamPreview.length > 0;
+
+      if (
+        !uiMsg?.parts?.length &&
+        !(event?.text as string | undefined) &&
+        !canPersistFromStreamImages
+      ) {
         console.warn(
-          `[Chat ${chatId}][${source === 'ui' ? 'uiOnFinish' : 'onFinish'}] Skipping persist: no UI parts and no stream text yet`
+          `[Chat ${chatId}][${source === 'ui' ? 'uiOnFinish' : 'onFinish'}] Skipping persist: no UI parts, stream text, or image URLs yet`
         );
         return;
       }
@@ -379,6 +414,16 @@ export function createChatStreamFinalizer(params: ChatStreamFinalizerParams) {
     }),
     async handleUiStreamFinish(responseMessage: UIMessage) {
       state.uiResponseMessage = responseMessage;
+
+      // streamText onFinish often arrives after UI onFinish for image/tool flows.
+      for (
+        let i = 0;
+        i < UI_FINISH_WAIT_MS / UI_FINISH_POLL_MS && !state.streamFinishEvent;
+        i++
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, UI_FINISH_POLL_MS));
+      }
+
       await persistAssistantMessages('ui', responseMessage);
     },
     handleStreamTextFinish(event: Record<string, unknown>, response: OpenRouterStreamResponse) {
@@ -422,7 +467,7 @@ export function createChatStreamFinalizer(params: ChatStreamFinalizerParams) {
         requestStartTime,
       });
 
-      void (async () => {
+      after(async () => {
         try {
           await finalizeAfterStream();
         } catch (persistError) {
@@ -433,7 +478,7 @@ export function createChatStreamFinalizer(params: ChatStreamFinalizerParams) {
         } catch (tokenError) {
           console.error(`[Chat ${chatId}][onFinish] Failed token tracking:`, tokenError);
         }
-      })();
+      });
     },
   };
 }

--- a/lib/chat/chatTools.ts
+++ b/lib/chat/chatTools.ts
@@ -1,0 +1,246 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import type { UIMessage } from 'ai';
+import { getUIMessageText } from '@/lib/message-utils';
+import { parseFile } from '@/lib/file-reader';
+import { fetchFileContent } from '@/lib/file-upload';
+import { WebFetchService, WebFetchError } from '@/lib/services/webFetchService';
+import type { AccessPolicyFlags } from '@/lib/config/access-policy';
+
+export function buildAttachedFileUrlByPath(messages: UIMessage[]): Map<string, string> {
+  const attachedFileUrlByPath = new Map<string, string>();
+  for (const msg of messages) {
+    if (msg.role !== 'user') continue;
+    const messageText = getUIMessageText(msg);
+    if (!messageText) continue;
+    const lines = messageText.split('\n');
+    for (const line of lines) {
+      const match = line.match(
+        /filepath:\s*([^\s|]+)\s*\|\s*url:\s*(https?:\/\/\S+)/i
+      );
+      if (match) {
+        attachedFileUrlByPath.set(match[1].trim(), match[2].trim());
+      }
+    }
+  }
+  return attachedFileUrlByPath;
+}
+
+export function buildWebFetchPolicy(accessPolicyFlags: AccessPolicyFlags) {
+  return {
+    ...WebFetchService.getDefaultPolicy(),
+    enabled: accessPolicyFlags.nativeWebFetchEnabled,
+    defaultMaxChars: accessPolicyFlags.nativeWebFetchMaxChars,
+    defaultTimeoutMs: accessPolicyFlags.nativeWebFetchTimeoutMs,
+    maxResponseBytes: accessPolicyFlags.nativeWebFetchMaxBytes,
+    maxRedirects: accessPolicyFlags.nativeWebFetchMaxRedirects,
+    siteModeEnabled: accessPolicyFlags.nativeWebFetchSiteModeEnabled,
+    siteModeMaxPages: accessPolicyFlags.nativeWebFetchSiteModeMaxPages,
+    siteModeDepth: accessPolicyFlags.nativeWebFetchSiteModeDepth,
+  };
+}
+
+export function buildReadFileTool(params: {
+  attachedFileUrlByPath: Map<string, string>;
+  projectFileUrlByPath: Map<string, string>;
+}) {
+  const { attachedFileUrlByPath, projectFileUrlByPath } = params;
+
+  return tool({
+    description:
+      'Read contents of a file uploaded by the user. Supports: CSV, Excel, PDF, text files, code files. Returns parsed content based on file type.',
+    inputSchema: z.object({
+      filepath: z
+        .string()
+        .describe(
+          'File path or full URL (e.g., "uploads/data-2024-02-06-143022.csv" or "https://...")'
+        ),
+    }),
+    execute: async ({ filepath }) => {
+      try {
+        const rawPath = (filepath || '').trim();
+        const normalizedPath = rawPath.startsWith('://')
+          ? `https${rawPath}`
+          : rawPath.startsWith('//')
+            ? `https:${rawPath}`
+            : rawPath;
+
+        const isFullUrl = /^https?:\/\//i.test(normalizedPath);
+        const blobBaseUrl =
+          process.env.BLOB_PUBLIC_URL || process.env.NEXT_PUBLIC_BLOB_URL;
+        const mappedUrl =
+          attachedFileUrlByPath.get(rawPath) ||
+          attachedFileUrlByPath.get(normalizedPath);
+        const projectMappedUrl =
+          projectFileUrlByPath.get(rawPath) ||
+          projectFileUrlByPath.get(normalizedPath);
+        const blobUrl = isFullUrl
+          ? normalizedPath
+          : mappedUrl
+            ? mappedUrl
+            : projectMappedUrl
+              ? projectMappedUrl
+              : blobBaseUrl
+                ? `${blobBaseUrl.replace(/\/$/, '')}/${normalizedPath.replace(/^\//, '')}`
+                : normalizedPath;
+
+        if (!/^https?:\/\//i.test(blobUrl)) {
+          return JSON.stringify({
+            success: false,
+            error:
+              'Invalid file reference. Expected an absolute URL or a filepath with BLOB_PUBLIC_URL configured.',
+          });
+        }
+
+        const result = await fetchFileContent(blobUrl);
+        if (!result.success || !result.content) {
+          return JSON.stringify({
+            success: false,
+            error: result.error || 'Failed to fetch file',
+          });
+        }
+
+        const buffer = Buffer.from(result.content);
+        const cleanPath = (result.finalUrl || filepath).split('?')[0].split('#')[0];
+        const filename = cleanPath.split('/').pop() || filepath;
+        const responseMimeType = result.contentType?.split(';')[0]?.trim();
+        const parseResult = await parseFile(buffer, filename, responseMimeType);
+
+        if (!parseResult.success) {
+          return JSON.stringify({
+            success: false,
+            error: parseResult.error || 'Failed to parse file',
+          });
+        }
+
+        return JSON.stringify(
+          { success: true, content: parseResult.content },
+          null,
+          2
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        console.error('[read_file] Error:', error);
+        return JSON.stringify({ success: false, error: message });
+      }
+    },
+  });
+}
+
+export function buildWebFetchTool(webFetchPolicy: ReturnType<typeof buildWebFetchPolicy>) {
+  return tool({
+    description:
+      'Fetch and extract readable content from a public web URL. Best for reading a specific link and using it as context.',
+    inputSchema: z.object({
+      url: z.string().describe('Public http/https URL to read'),
+      mode: z
+        .enum(['markdown', 'text'])
+        .optional()
+        .describe('Output format. Defaults to markdown.'),
+      maxChars: z
+        .number()
+        .int()
+        .positive()
+        .max(100000)
+        .optional()
+        .describe('Maximum characters to return. Defaults to server policy.'),
+      followRedirects: z
+        .boolean()
+        .optional()
+        .describe('Whether to follow redirects. Defaults to true.'),
+      timeoutMs: z
+        .number()
+        .int()
+        .positive()
+        .max(60000)
+        .optional()
+        .describe('Request timeout in milliseconds. Defaults to server policy.'),
+      siteMode: z
+        .boolean()
+        .optional()
+        .describe(
+          'Optional whole-site mode. Disabled unless explicitly enabled by server configuration.'
+        ),
+      siteModeSameDomain: z
+        .boolean()
+        .optional()
+        .describe('When siteMode is enabled, limit crawl to the same domain. Defaults to true.'),
+      siteModeMaxPages: z
+        .number()
+        .int()
+        .positive()
+        .max(100)
+        .optional()
+        .describe('When siteMode is enabled, maximum pages to crawl (capped by server policy).'),
+      siteModeDepth: z
+        .number()
+        .int()
+        .min(0)
+        .max(5)
+        .optional()
+        .describe('When siteMode is enabled, crawl depth (capped by server policy).'),
+    }),
+    execute: async ({
+      url,
+      mode,
+      maxChars,
+      followRedirects,
+      timeoutMs,
+      siteMode,
+      siteModeSameDomain,
+      siteModeMaxPages,
+      siteModeDepth,
+    }) => {
+      try {
+        const result = await WebFetchService.fetchPage(
+          {
+            url,
+            mode,
+            maxChars,
+            followRedirects,
+            timeoutMs,
+            siteMode,
+            siteModeSameDomain,
+            siteModeMaxPages,
+            siteModeDepth,
+          },
+          webFetchPolicy
+        );
+        return JSON.stringify({ success: true, ...result }, null, 2);
+      } catch (error) {
+        if (error instanceof WebFetchError) {
+          return JSON.stringify({
+            success: false,
+            code: error.code,
+            error: error.message,
+          });
+        }
+        const message =
+          error instanceof Error ? error.message : 'Unknown web fetch error';
+        return JSON.stringify({
+          success: false,
+          code: 'WEB_FETCH_UNKNOWN_ERROR',
+          error: message,
+        });
+      }
+    },
+  });
+}
+
+export function buildBaseChatTools(params: {
+  mcpTools: Record<string, unknown>;
+  messages: UIMessage[];
+  projectFileUrlByPath: Map<string, string>;
+  accessPolicyFlags: AccessPolicyFlags;
+}): Record<string, unknown> {
+  const { mcpTools, messages, projectFileUrlByPath, accessPolicyFlags } = params;
+  const attachedFileUrlByPath = buildAttachedFileUrlByPath(messages);
+  const webFetchPolicy = buildWebFetchPolicy(accessPolicyFlags);
+  const read_file = buildReadFileTool({ attachedFileUrlByPath, projectFileUrlByPath });
+
+  return {
+    ...mcpTools,
+    read_file,
+    ...(webFetchPolicy.enabled ? { web_fetch: buildWebFetchTool(webFetchPolicy) } : {}),
+  };
+}

--- a/lib/chat/createErrorResponse.ts
+++ b/lib/chat/createErrorResponse.ts
@@ -1,0 +1,11 @@
+export function createErrorResponse(
+  code: string,
+  message: string,
+  status: number,
+  details?: string
+): Response {
+  return new Response(
+    JSON.stringify({ error: { code, message, details } }),
+    { status, headers: { 'Content-Type': 'application/json' } }
+  );
+}

--- a/lib/chat/prepareMessagesForModel.ts
+++ b/lib/chat/prepareMessagesForModel.ts
@@ -1,0 +1,48 @@
+import type { UIMessage } from 'ai';
+import { convertToOpenRouterFormat } from '@/lib/openrouter-utils';
+import { ChatMessageProcessingService } from '@/lib/services/chatMessageProcessingService';
+import type { ModelInfo } from '@/lib/types/models';
+
+export interface PrepareMessagesParams {
+  messages: UIMessage[];
+  attachments: Array<{ name: string; contentType: string; url: string }>;
+  selectedModel: string;
+  modelInfo: ModelInfo | null;
+}
+
+export interface PreparedModelMessages {
+  modelMessagesFinal: UIMessage[];
+  /** OpenRouter/Requesty converted shape for streamText input. */
+  formattedMessages: ReturnType<typeof convertToOpenRouterFormat>;
+}
+
+export async function prepareMessagesForModel(
+  params: PrepareMessagesParams
+): Promise<PreparedModelMessages> {
+  const { messages, attachments, selectedModel, modelInfo } = params;
+
+  const processed = await ChatMessageProcessingService.processMessagesWithAttachments({
+    messages,
+    attachments,
+    modelInfo,
+  });
+
+  const modelMessagesFinal = ChatMessageProcessingService.addModelSpecificInstructions(
+    processed.messages,
+    selectedModel
+  );
+
+  const isOpenRouterModel = selectedModel.startsWith('openrouter/');
+  const isRequestyModel = selectedModel.startsWith('requesty/');
+  const needsFormatConversion = isOpenRouterModel || isRequestyModel;
+
+  let formattedMessages: ReturnType<typeof convertToOpenRouterFormat> = needsFormatConversion
+    ? convertToOpenRouterFormat(modelMessagesFinal)
+    : (modelMessagesFinal as ReturnType<typeof convertToOpenRouterFormat>);
+
+  formattedMessages = formattedMessages.filter(
+    (msg: { role?: string }) => msg.role !== 'tool'
+  );
+
+  return { modelMessagesFinal, formattedMessages };
+}

--- a/lib/chat/reasoningModels.ts
+++ b/lib/chat/reasoningModels.ts
@@ -1,0 +1,43 @@
+/** Models that receive tag-based reasoning system instructions. */
+export const REASONING_TAG_MODEL_IDS = [
+  'openrouter/deepseek/deepseek-r1',
+  'openrouter/deepseek/deepseek-r1-0528',
+  'openrouter/deepseek/deepseek-r1-0528-qwen3-8b',
+  'openrouter/x-ai/grok-3-beta',
+  'openrouter/x-ai/grok-3-mini-beta',
+  'openrouter/x-ai/grok-3-mini-beta-reasoning-high',
+  'openrouter/qwen/qwq-32b',
+] as const;
+
+export const REASONING_TAG_SYSTEM_PROMPT =
+  'Please provide your reasoning within <think> tags. After closing the </think> tag, provide your final answer directly without any other special tags.';
+
+/** Models that should disable logprobs in OpenRouter provider options. */
+export const LOGPROBS_DISABLED_MODEL_IDS = [
+  'openrouter/deepseek/deepseek-r1',
+  'openrouter/deepseek/deepseek-r1-0528',
+  'openrouter/x-ai/grok-3-beta',
+  'openrouter/x-ai/grok-3-mini-beta',
+  'openrouter/x-ai/grok-3-mini-beta-reasoning-high',
+  'openrouter/qwen/qwq-32b',
+] as const;
+
+export function modelUsesReasoningTagInstructions(selectedModel: string): boolean {
+  return REASONING_TAG_MODEL_IDS.includes(
+    selectedModel as (typeof REASONING_TAG_MODEL_IDS)[number]
+  );
+}
+
+export function modelShouldDisableLogprobs(selectedModel: string): boolean {
+  if (
+    LOGPROBS_DISABLED_MODEL_IDS.includes(
+      selectedModel as (typeof LOGPROBS_DISABLED_MODEL_IDS)[number]
+    )
+  ) {
+    return true;
+  }
+  return (
+    selectedModel.includes('openrouter/minimax/m2') ||
+    selectedModel.includes('openrouter/minimax-m2')
+  );
+}

--- a/lib/chat/streamTokenUsage.ts
+++ b/lib/chat/streamTokenUsage.ts
@@ -1,0 +1,181 @@
+import type { UIMessage } from 'ai';
+import { getUIMessageText } from '@/lib/message-utils';
+import { logDiagnostic } from '@/lib/utils/performantLogging';
+
+export interface TokenUsageSnapshot {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+}
+
+export interface ComputeStreamTokenUsageParams {
+  event: {
+    usage?: Record<string, unknown>;
+    steps?: Array<{ usage?: Record<string, unknown> }>;
+    durationMs?: number;
+  };
+  response: {
+    usage?: Record<string, unknown>;
+    messages?: Array<{ content?: unknown }>;
+  };
+  modelMessagesFinal: UIMessage[];
+  effectiveSystemInstruction: string;
+  requestId: string;
+}
+
+/** Aggregate usage from stream finish event/response with conversation-based fallbacks. */
+export function computeStreamTokenUsage(
+  params: ComputeStreamTokenUsageParams
+): TokenUsageSnapshot {
+  const { event, response, modelMessagesFinal, effectiveSystemInstruction, requestId } =
+    params;
+
+  const typedResponse = response;
+  let tokenUsageData: Record<string, unknown> | null =
+    (event.usage as Record<string, unknown>) ||
+    (typedResponse.usage as Record<string, unknown>) ||
+    null;
+
+  if (event.steps && Array.isArray(event.steps)) {
+    let totalStepInputTokens = 0;
+    let totalStepOutputTokens = 0;
+    let hasStepTokens = false;
+
+    for (const step of event.steps) {
+      if (step?.usage) {
+        const stepUsage = step.usage;
+        const stepInputTokens =
+          Number(stepUsage.promptTokens) ||
+          Number(stepUsage.inputTokens) ||
+          Number(stepUsage.prompt_tokens) ||
+          Number(stepUsage.input_tokens) ||
+          0;
+        const stepOutputTokens =
+          Number(stepUsage.completionTokens) ||
+          Number(stepUsage.outputTokens) ||
+          Number(stepUsage.completion_tokens) ||
+          Number(stepUsage.output_tokens) ||
+          0;
+
+        if (stepInputTokens > 0 || stepOutputTokens > 0) {
+          totalStepInputTokens += stepInputTokens;
+          totalStepOutputTokens += stepOutputTokens;
+          hasStepTokens = true;
+        }
+      }
+    }
+
+    if (hasStepTokens) {
+      tokenUsageData = {
+        ...tokenUsageData,
+        inputTokens:
+          totalStepInputTokens ||
+          Number(tokenUsageData?.inputTokens) ||
+          Number(tokenUsageData?.prompt_tokens) ||
+          0,
+        outputTokens:
+          totalStepOutputTokens ||
+          Number(tokenUsageData?.outputTokens) ||
+          Number(tokenUsageData?.completion_tokens) ||
+          0,
+        totalTokens:
+          totalStepInputTokens + totalStepOutputTokens ||
+          Number(tokenUsageData?.totalTokens) ||
+          Number(tokenUsageData?.total_tokens) ||
+          0,
+      };
+    }
+  }
+
+  const inputTokenCount =
+    Number(tokenUsageData?.inputTokens) || Number(tokenUsageData?.prompt_tokens) || 0;
+  const outputTokenCount =
+    Number(tokenUsageData?.outputTokens) ||
+    Number(tokenUsageData?.completion_tokens) ||
+    0;
+
+  const needsInputEstimation = !tokenUsageData || inputTokenCount === 0;
+  const needsOutputEstimation = !tokenUsageData || outputTokenCount === 0;
+
+  if (needsInputEstimation || needsOutputEstimation) {
+    const lastMessage = typedResponse.messages?.[typedResponse.messages.length - 1];
+    let outputContentLength = 0;
+    let inputContentLength = 0;
+
+    if (needsOutputEstimation && lastMessage?.content) {
+      if (Array.isArray(lastMessage.content)) {
+        outputContentLength = lastMessage.content
+          .filter((part: { type?: string }) => part.type === 'text')
+          .map((part: { text?: string }) => part.text ?? '')
+          .join('').length;
+      } else if (typeof lastMessage.content === 'string') {
+        outputContentLength = lastMessage.content.length;
+      }
+    }
+
+    if (needsInputEstimation) {
+      for (const message of modelMessagesFinal) {
+        inputContentLength += getUIMessageText(message).length;
+      }
+      if (effectiveSystemInstruction) {
+        inputContentLength += effectiveSystemInstruction.length;
+      }
+    }
+
+    const estimatedOutputTokens = Math.ceil(outputContentLength / 4);
+    const estimatedInputTokens = Math.ceil(inputContentLength / 4);
+
+    return {
+      inputTokens: needsInputEstimation ? estimatedInputTokens : inputTokenCount,
+      outputTokens: needsOutputEstimation ? estimatedOutputTokens : outputTokenCount,
+      totalTokens:
+        (needsInputEstimation ? estimatedInputTokens : inputTokenCount) +
+        (needsOutputEstimation ? estimatedOutputTokens : outputTokenCount),
+    };
+  }
+
+  logDiagnostic('STREAM_TOKEN_USAGE', 'Using provider-reported token usage', {
+    requestId,
+    inputTokenCount,
+    outputTokenCount,
+  });
+
+  return {
+    inputTokens: inputTokenCount,
+    outputTokens: outputTokenCount,
+    totalTokens: inputTokenCount + outputTokenCount,
+  };
+}
+
+export function estimateTimeToFirstTokenMs(params: {
+  timeToFirstTokenMs: number | null;
+  eventDurationMs?: number;
+  requestStartTime: number;
+}): number | null {
+  const { timeToFirstTokenMs, eventDurationMs, requestStartTime } = params;
+  if (timeToFirstTokenMs !== null) {
+    return timeToFirstTokenMs;
+  }
+  if (eventDurationMs) {
+    return Math.round(eventDurationMs * 0.2);
+  }
+  const calculatedProcessingTimeMs = Date.now() - requestStartTime;
+  return Math.round(calculatedProcessingTimeMs * 0.2);
+}
+
+export function computeTokensPerSecond(params: {
+  timeToFirstTokenMs: number | null;
+  outputTokens: number;
+  requestStartTime: number;
+}): number | null {
+  const { timeToFirstTokenMs, outputTokens, requestStartTime } = params;
+  if (timeToFirstTokenMs === null || outputTokens <= 0) {
+    return null;
+  }
+  const calculatedProcessingTimeMs = Date.now() - requestStartTime;
+  const generationTimeMs = calculatedProcessingTimeMs - timeToFirstTokenMs;
+  if (generationTimeMs <= 0) {
+    return null;
+  }
+  return outputTokens / (generationTimeMs / 1000);
+}

--- a/lib/chat/systemInstruction.ts
+++ b/lib/chat/systemInstruction.ts
@@ -1,0 +1,104 @@
+import { sanitizeSystemInstruction } from '@/lib/parameter-validation';
+
+export interface BuildSystemInstructionParams {
+  systemInstruction?: string;
+  webFetchEnabled: boolean;
+  webSearchUseAgenticServerTools: boolean;
+  effectiveWebSearchEnabled: boolean;
+  imageGenerationEnabled: boolean;
+  projectContextAppendix?: string;
+}
+
+export function buildDefaultSystemInstruction(
+  params: BuildSystemInstructionParams
+): string {
+  const {
+    systemInstruction,
+    webFetchEnabled,
+    webSearchUseAgenticServerTools,
+    effectiveWebSearchEnabled,
+    imageGenerationEnabled,
+    projectContextAppendix,
+  } = params;
+
+  if (systemInstruction !== undefined) {
+    let base = sanitizeSystemInstruction(systemInstruction);
+    if (projectContextAppendix) {
+      base = `${base}\n\n${projectContextAppendix}`;
+    }
+    return base;
+  }
+
+  const date = new Date().toISOString().split('T')[0];
+
+  let instruction = `You are a helpful AI assistant. Today's date is ${date}.
+
+You have access to external tools provided by connected servers. These tools can perform specific actions like running code, searching databases, or accessing external services.
+
+## File Attachments:
+When a user message contains an "[Attached files:]" section with "filepath" and/or "url":
+1. Use the \`read_file\` tool to inspect the relevant file(s) before answering questions about file contents.
+2. Prefer using the \`filepath\` value when provided; if unavailable, use the file URL.
+3. If reading a file fails, clearly explain what failed and what the user can retry.
+`;
+
+  if (webFetchEnabled) {
+    instruction += `
+## Native URL Fetch:
+When users ask to read, summarize, analyze, or extract information from a URL:
+1. Prefer the \`web_fetch\` tool for direct page reading.
+2. For messages containing multiple URLs, fetch the first URL unless the user explicitly asks for all.
+3. Only use \`siteMode: true\` when the user explicitly asks for whole-site or multi-page crawling.
+4. Cite the source URL in your response and mention when content was truncated.
+5. If fetching fails, explain the failure and suggest retrying or narrowing scope.
+`;
+  }
+
+  if (webSearchUseAgenticServerTools) {
+    instruction += `
+## Web Search Enabled (Agentic):
+You have the \`web_search\` server tool available. Use it when the user needs current information from the web.
+1. Only search when fresh information is required
+2. Cite sources using markdown links: [domain.com](full-url)
+3. Prefer OpenRouter fetch for pages discovered during search; use native \`web_fetch\` for explicit user-provided URLs
+`;
+  } else if (effectiveWebSearchEnabled) {
+    instruction += `
+## Web Search Enabled:
+You have web search capabilities enabled. When you use web search:
+1. Cite your sources using markdown links
+2. Use the format [domain.com](full-url) for citations
+3. Only cite reliable and relevant sources
+4. Integrate the information naturally into your responses
+`;
+  }
+
+  if (imageGenerationEnabled) {
+    instruction += `
+## Image Generation Enabled:
+You have the \`image_generation\` server tool available. Use it when the user wants you to create, draw, or generate an image.
+1. Call the tool with a detailed visual prompt when image creation is requested or clearly implied
+2. After generation, describe what was created and reference the image naturally in your reply
+3. If generation fails due to content policy, explain clearly and suggest a revised prompt
+`;
+  }
+
+  instruction += `
+## How to Respond:
+1.  **Analyze the Request:** Understand what the user is asking.
+2.  **Use Tools When Necessary:** If an external tool provides the best way to answer (e.g., fetching specific data, performing calculations, interacting with services), select the most relevant tool(s) and use them. You can use multiple tools in sequence. Clearly indicate when you are using a tool and what it's doing.
+3.  **Use Your Own Abilities:** For requests involving brainstorming, explanation, writing, summarization, analysis, or general knowledge, rely on your own reasoning and knowledge base. You don't need to force the use of an external tool if it's not suitable or required for these tasks.
+4.  **Respond Clearly:** Provide your answer directly when using your own abilities. If using tools, explain the steps taken and present the results clearly.
+5.  **Handle Limitations:** If you cannot answer fully (due to lack of information, missing tools, or capability limits), explain the limitation clearly. Don't just say "I don't know" if you can provide partial information or explain *why* you can't answer. If relevant tools seem to be missing, you can mention that the user could potentially add them via the server configuration.
+
+## Response Format:
+- Use Markdown for formatting.
+- Base your response on the results from any tools used, or on your own reasoning and knowledge.
+`;
+
+  if (projectContextAppendix) {
+    instruction += `\n\n${projectContextAppendix}`;
+  }
+
+  return instruction;
+}

--- a/lib/image-utils.ts
+++ b/lib/image-utils.ts
@@ -243,6 +243,37 @@ async function fileToDataUrl(file: File): Promise<string> {
     });
 }
 
+export async function downloadImageFromUrl(imageUrl: string, filename: string): Promise<void> {
+    const triggerDownload = (href: string) => {
+        const link = document.createElement('a');
+        link.href = href;
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+    };
+
+    // Same-origin data/blob URLs honor the download attribute directly.
+    if (imageUrl.startsWith('data:') || imageUrl.startsWith('blob:')) {
+        triggerDownload(imageUrl);
+        return;
+    }
+
+    // Cross-origin URLs ignore the download attribute; fetch and save as a blob instead.
+    const response = await fetch(imageUrl);
+    if (!response.ok) {
+        throw new Error(`Failed to download image (${response.status})`);
+    }
+
+    const blob = await response.blob();
+    const objectUrl = URL.createObjectURL(blob);
+    try {
+        triggerDownload(objectUrl);
+    } finally {
+        URL.revokeObjectURL(objectUrl);
+    }
+}
+
 export function formatFileSize(bytes: number): string {
     if (bytes === 0) return '0 Bytes';
 

--- a/lib/services/__tests__/chatAuthenticationService.test.ts
+++ b/lib/services/__tests__/chatAuthenticationService.test.ts
@@ -11,14 +11,14 @@ jest.mock('@/lib/utils/performantLogging', () => ({
     logDiagnostic: jest.fn()
 }));
 
-jest.mock('@/app/api/chat/route', () => ({
+jest.mock('@/lib/chat/createErrorResponse', () => ({
     createErrorResponse: jest.fn()
-}), { virtual: true });
+}));
 
 import { ChatAuthenticationService, AuthenticatedUser } from '../chatAuthenticationService';
 import { auth } from '@/lib/auth';
 import { logDiagnostic } from '@/lib/utils/performantLogging';
-import { createErrorResponse } from '@/app/api/chat/route';
+import { createErrorResponse } from '@/lib/chat/createErrorResponse';
 
 describe('ChatAuthenticationService', () => {
     const mockAuth = auth.api.getSession as jest.MockedFunction<typeof auth.api.getSession>;

--- a/lib/services/chatMessageProcessingService.ts
+++ b/lib/services/chatMessageProcessingService.ts
@@ -2,6 +2,11 @@ import type { UIMessage } from "ai";
 import type { ModelInfo } from "@/lib/types/models";
 import type { ImageUIPart } from '@/lib/types';
 import { getUIMessageText } from '@/lib/message-utils';
+import {
+    modelUsesReasoningTagInstructions,
+    REASONING_TAG_SYSTEM_PROMPT,
+} from '@/lib/chat/reasoningModels';
+import { nanoid } from 'nanoid';
 
 export interface MessageProcessingContext {
     messages: UIMessage[];
@@ -121,16 +126,11 @@ export class ChatMessageProcessingService {
     static addModelSpecificInstructions(messages: UIMessage[], selectedModel: string): UIMessage[] {
         const modelMessages = [...messages];
 
-        if (
-            selectedModel === "openrouter/deepseek/deepseek-r1" ||
-            selectedModel === "openrouter/deepseek/deepseek-r1-0528-qwen3-8b" ||
-            selectedModel === "openrouter/qwen/qwq-32b"
-        ) {
-            const systemContent = "Please provide your reasoning within <think> tags. After closing the </think> tag, provide your final answer directly without any other special tags.";
+        if (modelUsesReasoningTagInstructions(selectedModel)) {
             modelMessages.unshift({
                 role: "system",
-                id: `system_${Date.now()}`,
-                parts: [{ type: "text", text: systemContent }]
+                id: nanoid(),
+                parts: [{ type: "text", text: REASONING_TAG_SYSTEM_PROMPT }]
             });
         }
 

--- a/lib/services/chatTokenTrackingService.ts
+++ b/lib/services/chatTokenTrackingService.ts
@@ -32,6 +32,8 @@ export interface TokenTrackingContext {
     shouldDeductCredits: boolean;
     webSearchEnabled: boolean;
     webSearchCost: number;
+    /** When set, replaces the default web-search-only additional cost calculation. */
+    additionalCost?: number;
     apiKeys?: Record<string, string>;
     modelInfo?: ModelInfo; // Model information for variable credit cost calculation
 }
@@ -103,8 +105,12 @@ export class ChatTokenTrackingService {
                 }
             }
 
-            // Calculate additional cost for web search
-            const additionalCost = webSearchEnabled && !isUsingOwnApiKeys && shouldDeductCredits ? webSearchCost : 0;
+            const additionalCost =
+                context.additionalCost !== undefined
+                    ? context.additionalCost
+                    : webSearchEnabled && !isUsingOwnApiKeys && shouldDeductCredits
+                      ? webSearchCost
+                      : 0;
 
             // Fetch modelInfo if not provided (needed for variable credit cost calculation)
             let modelInfo = context.modelInfo;

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "thermo-nuclear-code-quality-review": {
+      "source": "cursor/plugins",
+      "sourceType": "github",
+      "skillPath": "cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md",
+      "computedHash": "9052b01b46b1d8dbf94c45f9313ec1983443f9a460e83d49cdc7fe0f640ca476"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Decomposes the ~2k-line `POST /api/chat` handler into focused modules under `lib/chat/` (request parsing, preflight, message preparation, tools, stream plan, stream finalization, token usage, reasoning model registry).
- Routes token tracking through `ChatTokenTrackingService` and removes duplicate attachment processing.
- Adds optional `createdAt` on chat UI messages and normalizes timestamps in `convertToDBMessages` so persisted message order stays stable when timestamps collide.

## Test plan

- [ ] `pnpm lint`
- [ ] `pnpm test:unit` (includes new `chat-store` ordering tests)
- [ ] `pnpm build`
- [ ] Manual smoke: send multi-turn chat, stop generation, web search, image generation, MCP tools
- [ ] Reload chat history and confirm message order matches send order


Made with [Cursor](https://cursor.com)